### PR TITLE
Refine loading screen transitions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,9 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+import clsx from 'clsx';
+
+import LoadingScreen, { type LoadingStage } from '@/components/LoadingScreen';
 import AnimatedBackground from '@/components/animations/AnimatedBackground';
 import Navigation from '@/components/sections/Navigation';
 import Hero from '@/components/sections/Hero';
@@ -8,14 +12,70 @@ import About from '@/components/sections/About';
 import Certificates from '@/components/sections/Certificates';
 
 export default function Home() {
+  const [progress, setProgress] = useState(0);
+  const [stage, setStage] = useState<LoadingStage>('loading');
+
+  useEffect(() => {
+    if (stage !== 'loading') {
+      return;
+    }
+
+    const timer = setInterval(() => {
+      setProgress((prev) => {
+        if (prev >= 100) {
+          return prev;
+        }
+
+        const increment = Math.floor(Math.random() * 4) + 1;
+        const nextValue = Math.min(prev + increment, 100);
+
+        if (nextValue === 100) {
+          clearInterval(timer);
+        }
+
+        return nextValue;
+      });
+    }, 40);
+
+    return () => {
+      clearInterval(timer);
+    };
+  }, [stage]);
+
+  useEffect(() => {
+    if (stage === 'loading' && progress === 100) {
+      setStage('transition');
+    }
+  }, [progress, stage]);
+
+  useEffect(() => {
+    if (stage === 'transition') {
+      const timeout = setTimeout(() => {
+        setStage('final');
+      }, 900);
+
+      return () => clearTimeout(timeout);
+    }
+  }, [stage]);
+
+  const contentClasses = clsx(
+    'relative z-10 transition-all duration-700 ease-out',
+    stage === 'final'
+      ? 'opacity-100 blur-0 pointer-events-auto'
+      : 'opacity-30 blur-sm pointer-events-none animate-content-flow motion-reduce:animate-none'
+  );
+
   return (
     <main className="min-h-screen bg-slate-900 text-white overflow-x-hidden">
-      <AnimatedBackground />
-      <Navigation />
-      <Hero />
-      <Projects />
-      <About />
-      <Certificates />
+      <LoadingScreen progress={progress} stage={stage} />
+      <div className={contentClasses}>
+        <AnimatedBackground />
+        <Navigation />
+        <Hero />
+        <Projects />
+        <About />
+        <Certificates />
+      </div>
     </main>
   );
 }

--- a/components/LoadingScreen.tsx
+++ b/components/LoadingScreen.tsx
@@ -1,0 +1,68 @@
+import clsx from 'clsx';
+
+export type LoadingStage = 'loading' | 'transition' | 'final';
+
+type LoadingScreenProps = {
+  progress: number;
+  stage: LoadingStage;
+};
+
+export default function LoadingScreen({ progress, stage }: LoadingScreenProps) {
+  const progressValue = Math.round(Math.min(Math.max(progress, 0), 100));
+
+  const overlayClasses = clsx(
+    'fixed inset-0 z-40 bg-slate-950/95 transition-opacity duration-700',
+    stage === 'loading' ? 'opacity-100' : 'opacity-0',
+    stage === 'final' ? 'pointer-events-none' : 'pointer-events-auto'
+  );
+
+  const logoWrapperClasses = clsx(
+    'fixed z-50 flex items-center justify-center text-white font-semibold transition-all duration-700 ease-out',
+    stage === 'loading'
+      ? 'top-1/2 left-1/2 h-56 w-56 -translate-x-1/2 -translate-y-1/2'
+      : 'top-6 left-6 h-16 w-16 translate-x-0 translate-y-0 sm:h-20 sm:w-20'
+  );
+
+  const logoTextClasses = clsx(
+    'tracking-[0.5em] lowercase transition-all duration-700 ease-out',
+    stage === 'loading' ? 'text-4xl sm:text-5xl' : 'text-base sm:text-lg tracking-[0.35em]'
+  );
+
+  const ringClasses = clsx(
+    'absolute inset-0 rounded-full transition-all duration-700 ease-out',
+    stage === 'final' ? 'border border-slate-500/70 bg-slate-900/90' : 'border border-transparent'
+  );
+
+  const ringStyle =
+    stage === 'final'
+      ? undefined
+      : {
+          background: `conic-gradient(#38bdf8 ${progressValue * 3.6}deg, rgba(148, 163, 184, 0.15) ${
+            progressValue * 3.6
+          }deg)`,
+        };
+
+  return (
+    <>
+      <div className={overlayClasses} />
+      <div className={logoWrapperClasses}>
+        <div className="relative flex h-full w-full items-center justify-center">
+          <div className={ringClasses} style={ringStyle} />
+          <div
+            className={clsx(
+              'absolute inset-[12%] flex items-center justify-center rounded-full bg-slate-950 shadow-[0_0_50px_rgba(56,189,248,0.35)] transition-all duration-700 ease-out',
+              stage !== 'loading' && 'shadow-none'
+            )}
+          >
+            <span className={logoTextClasses}>am</span>
+          </div>
+          {stage === 'loading' && (
+            <span className="absolute -bottom-14 text-xs font-medium tracking-[0.35em] text-slate-300">
+              {progressValue}%
+            </span>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -78,10 +78,21 @@ const config: Config = {
             height: '0',
           },
         },
+        'content-flow': {
+          '0%, 100%': {
+            transform: 'translateY(0)',
+            opacity: '0.35',
+          },
+          '50%': {
+            transform: 'translateY(-3%)',
+            opacity: '0.15',
+          },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
+        'content-flow': 'content-flow 10s ease-in-out infinite',
       },
     },
   },


### PR DESCRIPTION
## Summary
- export the loading stage type for reuse and keep the overlay interactive until the final state
- block page interactions while the dimmed background animation plays and restore them once loading finishes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dd9e778c5c8322bc6f922c4ada0599