### PR TITLE
feat: enterprise roadmap and admin curriculum workflow

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -38,7 +38,7 @@ import {
   updateDailyLog,
   updateRoadmapItem,
 } from '@/lib/roadmap/queries';
-import type { CurriculumDayTemplate } from '@/types/curriculum';
+import type { CurriculumDay } from '@/types/curriculum';
 import type { AdminRoadmapDataSet, ArtifactRow, DailyLogRow, RoadmapItem, TagRow } from '@/types/roadmap';
 
 type FlatDailyLog = DailyLogRow & { roadmapTitle: string };
@@ -151,14 +151,14 @@ function AdminWorkspace({ user, signOut }: { user: User; signOut: () => Promise<
     return ids;
   }, [data.items, user.id]);
 
-  const handleCreateCurriculumLog = async (day: CurriculumDayTemplate) => {
-    if (completedDayIds.has(day.id)) {
-      setMessage(`${day.id} already has a daily log.`);
+  const handleCreateCurriculumLog = async (day: CurriculumDay) => {
+    if (completedDayIds.has(day.key)) {
+      setMessage(`${day.key} already has a daily log.`);
       setError(null);
       return;
     }
 
-    setCreatingDayId(day.id);
+    setCreatingDayId(day.key);
     await withFeedback(async () => {
       const weekMilestoneIds = await ensureWeekMilestones();
       const milestoneId = weekMilestoneIds.get(day.week);
@@ -178,7 +178,7 @@ function AdminWorkspace({ user, signOut }: { user: User; signOut: () => Promise<
         actual_hours: template.plannedHours,
         is_public: true,
       });
-    }, `${day.id} daily log created from template.`);
+    }, `${day.key} daily log created from template.`);
     setCreatingDayId(null);
   };
 

--- a/app/roadmap/page.tsx
+++ b/app/roadmap/page.tsx
@@ -4,7 +4,7 @@ import RoadmapHiringView from '@/components/roadmap/RoadmapHiringView';
 
 export const metadata: Metadata = {
   title: 'Roadmap - Alperen Manas',
-  description: 'Interactive roadmap with hiring view, timeline, artifacts, and weekly deep dive.',
+  description: 'Plan and execution roadmap with curriculum tracking, timeline, artifacts, and weekly deep dive.',
 };
 
 export default function RoadmapPage() {

--- a/components/admin/CurriculumPanel.tsx
+++ b/components/admin/CurriculumPanel.tsx
@@ -9,13 +9,13 @@ import CurriculumJumpDialog from '@/components/curriculum/CurriculumJumpDialog';
 import TodayFocusCard from '@/components/curriculum/TodayFocusCard';
 import CurriculumWeekGrid from '@/components/curriculum/CurriculumWeekGrid';
 import { groupByWeek } from '@/lib/curriculum/month1-utils';
-import type { CurriculumDayTemplate, CurriculumProgress } from '@/types/curriculum';
+import type { CurriculumDay, CurriculumProgress } from '@/types/curriculum';
 
 type CurriculumPanelProps = {
   progress: CurriculumProgress;
   completedDayIds: Set<string>;
-  nextDay: CurriculumDayTemplate | null;
-  onCreateDailyLog: (day: CurriculumDayTemplate) => Promise<void>;
+  nextDay: CurriculumDay | null;
+  onCreateDailyLog: (day: CurriculumDay) => Promise<void>;
   creatingDayId: string | null;
 };
 
@@ -27,10 +27,10 @@ export default function CurriculumPanel({
   creatingDayId,
 }: CurriculumPanelProps) {
   const weeks = useMemo(() => groupByWeek(MONTH1), []);
-  const [selectedDay, setSelectedDay] = useState<CurriculumDayTemplate | null>(nextDay ?? MONTH1[0] ?? null);
+  const [selectedDay, setSelectedDay] = useState<CurriculumDay | null>(nextDay ?? MONTH1[0] ?? null);
   const [drawerOpen, setDrawerOpen] = useState(false);
 
-  const openDay = (day: CurriculumDayTemplate) => {
+  const openDay = (day: CurriculumDay) => {
     setSelectedDay(day);
     setDrawerOpen(true);
   };
@@ -63,7 +63,7 @@ export default function CurriculumPanel({
           </p>
           <p className="mt-2 text-2xl font-semibold text-white">
             {Array.from({ length: 4 }, (_, index) => index + 1).filter((week) =>
-              MONTH1.filter((day) => day.week === week).every((day) => completedDayIds.has(day.id)),
+              MONTH1.filter((day) => day.week === week).every((day) => completedDayIds.has(day.key)),
             ).length}
             /4
           </p>
@@ -96,7 +96,7 @@ export default function CurriculumPanel({
           weeks={weeks}
           completedDayIds={completedDayIds}
           onSelectDay={openDay}
-          selectedDayId={selectedDay?.id ?? null}
+          selectedDayId={selectedDay?.key ?? null}
         />
       </div>
 
@@ -104,8 +104,8 @@ export default function CurriculumPanel({
         day={selectedDay}
         open={drawerOpen}
         onOpenChange={setDrawerOpen}
-        isCompleted={selectedDay ? completedDayIds.has(selectedDay.id) : false}
-        creating={selectedDay ? creatingDayId === selectedDay.id : false}
+        isCompleted={selectedDay ? completedDayIds.has(selectedDay.key) : false}
+        creating={selectedDay ? creatingDayId === selectedDay.key : false}
         onCreateDailyLog={onCreateDailyLog}
       />
     </section>

--- a/components/admin/CurriculumPanel.tsx
+++ b/components/admin/CurriculumPanel.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { CalendarRange, CheckCircle2, Target } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import { MONTH1 } from '@/content/curriculum/month1';
+import CurriculumDayDrawer from '@/components/curriculum/CurriculumDayDrawer';
+import CurriculumJumpDialog from '@/components/curriculum/CurriculumJumpDialog';
+import TodayFocusCard from '@/components/curriculum/TodayFocusCard';
+import CurriculumWeekGrid from '@/components/curriculum/CurriculumWeekGrid';
+import { groupByWeek } from '@/lib/curriculum/month1-utils';
+import type { CurriculumDayTemplate, CurriculumProgress } from '@/types/curriculum';
+
+type CurriculumPanelProps = {
+  progress: CurriculumProgress;
+  completedDayIds: Set<string>;
+  nextDay: CurriculumDayTemplate | null;
+  onCreateDailyLog: (day: CurriculumDayTemplate) => Promise<void>;
+  creatingDayId: string | null;
+};
+
+export default function CurriculumPanel({
+  progress,
+  completedDayIds,
+  nextDay,
+  onCreateDailyLog,
+  creatingDayId,
+}: CurriculumPanelProps) {
+  const weeks = useMemo(() => groupByWeek(MONTH1), []);
+  const [selectedDay, setSelectedDay] = useState<CurriculumDayTemplate | null>(nextDay ?? MONTH1[0] ?? null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const openDay = (day: CurriculumDayTemplate) => {
+    setSelectedDay(day);
+    setDrawerOpen(true);
+  };
+
+  return (
+    <section className="space-y-4">
+      <TodayFocusCard
+        heading="Admin Curriculum"
+        progress={progress}
+        nextDay={nextDay}
+        ctaLabel={nextDay ? 'Open Today Focus' : undefined}
+        onCta={nextDay ? () => openDay(nextDay) : undefined}
+      />
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="rounded-2xl border border-slate-700/70 bg-slate-900/70 p-4">
+          <p className="inline-flex items-center gap-2 text-xs uppercase tracking-[0.14em] text-slate-300">
+            <Target size={14} />
+            Completion
+          </p>
+          <p className="mt-2 text-2xl font-semibold text-white">
+            {progress.completedDays}/{progress.totalDays}
+          </p>
+          <p className="text-xs text-slate-400">Month 1 day coverage</p>
+        </div>
+        <div className="rounded-2xl border border-slate-700/70 bg-slate-900/70 p-4">
+          <p className="inline-flex items-center gap-2 text-xs uppercase tracking-[0.14em] text-slate-300">
+            <CheckCircle2 size={14} />
+            Weeks Done
+          </p>
+          <p className="mt-2 text-2xl font-semibold text-white">
+            {Array.from({ length: 4 }, (_, index) => index + 1).filter((week) =>
+              MONTH1.filter((day) => day.week === week).every((day) => completedDayIds.has(day.id)),
+            ).length}
+            /4
+          </p>
+          <p className="text-xs text-slate-400">Week milestone completion</p>
+        </div>
+        <div className="rounded-2xl border border-slate-700/70 bg-slate-900/70 p-4">
+          <p className="inline-flex items-center gap-2 text-xs uppercase tracking-[0.14em] text-slate-300">
+            <CalendarRange size={14} />
+            Jump
+          </p>
+          <div className="mt-2">
+            <CurriculumJumpDialog days={MONTH1} onSelectDay={openDay} />
+          </div>
+          <p className="mt-2 text-xs text-slate-400">Quick access by W#D# prefix</p>
+        </div>
+      </div>
+
+      <div className="rounded-3xl border border-cyan-500/20 bg-gradient-to-br from-slate-900 via-slate-900 to-slate-950 p-4 shadow-[0_18px_70px_rgba(8,145,178,0.2)]">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-xs uppercase tracking-[0.18em] text-cyan-200">Curriculum Control Center</p>
+            <h3 className="text-lg font-semibold text-white">Week 1 - Week 4 daily execution</h3>
+          </div>
+          <p className="text-xs text-slate-300">
+            Click any day for details, then generate a daily log template in one action.
+          </p>
+        </div>
+
+        <CurriculumWeekGrid
+          weeks={weeks}
+          completedDayIds={completedDayIds}
+          onSelectDay={openDay}
+          selectedDayId={selectedDay?.id ?? null}
+        />
+      </div>
+
+      <CurriculumDayDrawer
+        day={selectedDay}
+        open={drawerOpen}
+        onOpenChange={setDrawerOpen}
+        isCompleted={selectedDay ? completedDayIds.has(selectedDay.id) : false}
+        creating={selectedDay ? creatingDayId === selectedDay.id : false}
+        onCreateDailyLog={onCreateDailyLog}
+      />
+    </section>
+  );
+}

--- a/components/curriculum/CurriculumDayDrawer.tsx
+++ b/components/curriculum/CurriculumDayDrawer.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { Loader2, PlayCircle } from 'lucide-react';
+
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer';
+import type { CurriculumDayTemplate } from '@/types/curriculum';
+
+type CurriculumDayDrawerProps = {
+  day: CurriculumDayTemplate | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  isCompleted: boolean;
+  onCreateDailyLog?: (day: CurriculumDayTemplate) => Promise<void>;
+  creating?: boolean;
+};
+
+function Section({ title, items }: { title: string; items: string[] }) {
+  return (
+    <section className="space-y-2">
+      <p className="text-xs uppercase tracking-[0.16em] text-slate-400">{title}</p>
+      <ul className="space-y-2">
+        {items.map((item, index) => (
+          <li key={`${title}-${index}`} className="rounded-xl border border-slate-700/70 bg-slate-950/70 p-3 text-sm text-slate-200">
+            {item}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default function CurriculumDayDrawer({
+  day,
+  open,
+  onOpenChange,
+  isCompleted,
+  onCreateDailyLog,
+  creating = false,
+}: CurriculumDayDrawerProps) {
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent className="max-h-[92vh] border-slate-700 bg-slate-900 text-slate-100">
+        <DrawerHeader className="border-b border-slate-700/80">
+          {day ? (
+            <>
+              <p className="text-xs uppercase tracking-[0.18em] text-cyan-200">{day.id}</p>
+              <DrawerTitle className="text-2xl text-white">{day.title}</DrawerTitle>
+              <DrawerDescription className="space-y-1 text-slate-300">
+                <span className="block">{day.focus}</span>
+                <span className="block">
+                  Target date: {day.suggestedDate} - Planned {day.plannedHours.toFixed(1)}h
+                </span>
+              </DrawerDescription>
+            </>
+          ) : (
+            <DrawerTitle className="text-white">No day selected</DrawerTitle>
+          )}
+        </DrawerHeader>
+
+        <div className="space-y-4 overflow-y-auto px-4 py-4">
+          {!day && <p className="text-sm text-slate-300">Select a curriculum day to inspect details.</p>}
+
+          {day && (
+            <>
+              <section className="rounded-2xl border border-cyan-400/20 bg-cyan-400/5 p-4">
+                <p className="text-xs uppercase tracking-[0.16em] text-cyan-200">Summary</p>
+                <p className="mt-2 text-sm text-slate-100">{day.summary}</p>
+              </section>
+
+              <section className="space-y-2">
+                <p className="text-xs uppercase tracking-[0.16em] text-slate-400">Video Links</p>
+                <div className="grid gap-2 md:grid-cols-2">
+                  {day.videoLinks.map((link) => (
+                    <a
+                      key={link.url}
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="rounded-xl border border-slate-700/70 bg-slate-950/70 p-3 text-sm text-cyan-200 transition hover:border-cyan-300/60 hover:text-cyan-100"
+                    >
+                      {link.label}
+                    </a>
+                  ))}
+                </div>
+              </section>
+
+              <Section title="Build Steps" items={day.buildSteps} />
+              <Section title="Definition of Done" items={day.definitionOfDone} />
+              <Section title="Artifact Targets" items={day.artifactTargets} />
+            </>
+          )}
+        </div>
+
+        {day && onCreateDailyLog && (
+          <DrawerFooter className="border-t border-slate-700/80">
+            <button
+              type="button"
+              disabled={creating || isCompleted}
+              onClick={() => void onCreateDailyLog(day)}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-cyan-500 to-blue-500 px-4 py-3 text-sm font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:from-slate-700 disabled:to-slate-600"
+            >
+              {creating ? <Loader2 size={16} className="animate-spin" /> : <PlayCircle size={16} />}
+              {isCompleted ? 'Already completed' : 'Create Daily Log from template'}
+            </button>
+          </DrawerFooter>
+        )}
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/components/curriculum/CurriculumDayDrawer.tsx
+++ b/components/curriculum/CurriculumDayDrawer.tsx
@@ -10,14 +10,15 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from '@/components/ui/drawer';
-import type { CurriculumDayTemplate } from '@/types/curriculum';
+import { getCurriculumSuggestedDate } from '@/lib/curriculum/month1-utils';
+import type { CurriculumDay } from '@/types/curriculum';
 
 type CurriculumDayDrawerProps = {
-  day: CurriculumDayTemplate | null;
+  day: CurriculumDay | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   isCompleted: boolean;
-  onCreateDailyLog?: (day: CurriculumDayTemplate) => Promise<void>;
+  onCreateDailyLog?: (day: CurriculumDay) => Promise<void>;
   creating?: boolean;
 };
 
@@ -50,12 +51,12 @@ export default function CurriculumDayDrawer({
         <DrawerHeader className="border-b border-slate-700/80">
           {day ? (
             <>
-              <p className="text-xs uppercase tracking-[0.18em] text-cyan-200">{day.id}</p>
+              <p className="text-xs uppercase tracking-[0.18em] text-cyan-200">{day.key}</p>
               <DrawerTitle className="text-2xl text-white">{day.title}</DrawerTitle>
               <DrawerDescription className="space-y-1 text-slate-300">
                 <span className="block">{day.focus}</span>
                 <span className="block">
-                  Target date: {day.suggestedDate} - Planned {day.plannedHours.toFixed(1)}h
+                  Target date: {getCurriculumSuggestedDate(day)} - Planned {day.timeboxHours.toFixed(1)}h
                 </span>
               </DrawerDescription>
             </>
@@ -69,15 +70,10 @@ export default function CurriculumDayDrawer({
 
           {day && (
             <>
-              <section className="rounded-2xl border border-cyan-400/20 bg-cyan-400/5 p-4">
-                <p className="text-xs uppercase tracking-[0.16em] text-cyan-200">Summary</p>
-                <p className="mt-2 text-sm text-slate-100">{day.summary}</p>
-              </section>
-
               <section className="space-y-2">
                 <p className="text-xs uppercase tracking-[0.16em] text-slate-400">Video Links</p>
                 <div className="grid gap-2 md:grid-cols-2">
-                  {day.videoLinks.map((link) => (
+                  {day.video.map((link) => (
                     <a
                       key={link.url}
                       href={link.url}
@@ -85,15 +81,20 @@ export default function CurriculumDayDrawer({
                       rel="noopener noreferrer"
                       className="rounded-xl border border-slate-700/70 bg-slate-950/70 p-3 text-sm text-cyan-200 transition hover:border-cyan-300/60 hover:text-cyan-100"
                     >
-                      {link.label}
+                      <span className="font-semibold">{link.title}</span>
+                      {link.notes && <span className="mt-1 block text-xs text-slate-300">{link.notes}</span>}
                     </a>
                   ))}
+                  {day.video.length === 0 && (
+                    <p className="rounded-xl border border-slate-700/70 bg-slate-950/70 p-3 text-sm text-slate-300">
+                      No video resource for this day.
+                    </p>
+                  )}
                 </div>
               </section>
 
-              <Section title="Build Steps" items={day.buildSteps} />
-              <Section title="Definition of Done" items={day.definitionOfDone} />
-              <Section title="Artifact Targets" items={day.artifactTargets} />
+              <Section title="Build Steps" items={day.build} />
+              <Section title="Definition of Done" items={day.dod} />
             </>
           )}
         </div>

--- a/components/curriculum/CurriculumJumpDialog.tsx
+++ b/components/curriculum/CurriculumJumpDialog.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import type { CurriculumDayTemplate } from '@/types/curriculum';
+
+type CurriculumJumpDialogProps = {
+  days: CurriculumDayTemplate[];
+  onSelectDay: (day: CurriculumDayTemplate) => void;
+};
+
+export default function CurriculumJumpDialog({ days, onSelectDay }: CurriculumJumpDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  const sortedDays = useMemo(
+    () => [...days].sort((left, right) => (left.week - right.week) || (left.day - right.day)),
+    [days],
+  );
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-2 rounded-xl border border-slate-600 bg-slate-900/70 px-3 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-slate-200 transition hover:border-cyan-300/60 hover:text-cyan-100"
+      >
+        <Search size={14} />
+        Jump to day
+      </button>
+      <CommandDialog open={open} onOpenChange={setOpen}>
+        <CommandInput placeholder="Search W1D1, focus, or title..." />
+        <CommandList>
+          <CommandEmpty>No curriculum day found.</CommandEmpty>
+          <CommandGroup heading="Month 1">
+            {sortedDays.map((day) => (
+              <CommandItem
+                key={day.id}
+                value={`${day.id} ${day.title} ${day.focus}`}
+                onSelect={() => {
+                  onSelectDay(day);
+                  setOpen(false);
+                }}
+              >
+                <div className="flex w-full flex-col">
+                  <span className="text-xs uppercase tracking-[0.14em] text-slate-400">{day.id}</span>
+                  <span className="text-sm text-slate-100">{day.title}</span>
+                  <span className="text-xs text-slate-400">{day.focus}</span>
+                </div>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </CommandList>
+      </CommandDialog>
+    </>
+  );
+}

--- a/components/curriculum/CurriculumJumpDialog.tsx
+++ b/components/curriculum/CurriculumJumpDialog.tsx
@@ -11,11 +11,11 @@ import {
   CommandItem,
   CommandList,
 } from '@/components/ui/command';
-import type { CurriculumDayTemplate } from '@/types/curriculum';
+import type { CurriculumDay } from '@/types/curriculum';
 
 type CurriculumJumpDialogProps = {
-  days: CurriculumDayTemplate[];
-  onSelectDay: (day: CurriculumDayTemplate) => void;
+  days: CurriculumDay[];
+  onSelectDay: (day: CurriculumDay) => void;
 };
 
 export default function CurriculumJumpDialog({ days, onSelectDay }: CurriculumJumpDialogProps) {
@@ -43,15 +43,15 @@ export default function CurriculumJumpDialog({ days, onSelectDay }: CurriculumJu
           <CommandGroup heading="Month 1">
             {sortedDays.map((day) => (
               <CommandItem
-                key={day.id}
-                value={`${day.id} ${day.title} ${day.focus}`}
+                key={day.key}
+                value={`${day.key} ${day.title} ${day.focus}`}
                 onSelect={() => {
                   onSelectDay(day);
                   setOpen(false);
                 }}
               >
                 <div className="flex w-full flex-col">
-                  <span className="text-xs uppercase tracking-[0.14em] text-slate-400">{day.id}</span>
+                  <span className="text-xs uppercase tracking-[0.14em] text-slate-400">{day.key}</span>
                   <span className="text-sm text-slate-100">{day.title}</span>
                   <span className="text-xs text-slate-400">{day.focus}</span>
                 </div>

--- a/components/curriculum/CurriculumWeekGrid.tsx
+++ b/components/curriculum/CurriculumWeekGrid.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { Check, CircleDot, Play } from 'lucide-react';
+
+import type { CurriculumDayTemplate, CurriculumWeekGroup } from '@/types/curriculum';
+
+type CurriculumWeekGridProps = {
+  weeks: CurriculumWeekGroup[];
+  completedDayIds: Set<string>;
+  onSelectDay: (day: CurriculumDayTemplate) => void;
+  selectedDayId?: string | null;
+};
+
+function getDayState(
+  day: CurriculumDayTemplate,
+  completedDayIds: Set<string>,
+  selectedDayId: string | null | undefined,
+): 'completed' | 'active' | 'pending' {
+  if (completedDayIds.has(day.id)) {
+    return 'completed';
+  }
+  if (selectedDayId === day.id) {
+    return 'active';
+  }
+  return 'pending';
+}
+
+function getDayClassName(state: 'completed' | 'active' | 'pending'): string {
+  if (state === 'completed') {
+    return 'border-emerald-400/60 bg-emerald-500/10 text-emerald-100';
+  }
+  if (state === 'active') {
+    return 'border-cyan-300/70 bg-cyan-500/10 text-cyan-100';
+  }
+  return 'border-slate-600/70 bg-slate-900/70 text-slate-100 hover:border-cyan-300/50';
+}
+
+function DayIcon({ state }: { state: 'completed' | 'active' | 'pending' }) {
+  if (state === 'completed') {
+    return <Check size={14} />;
+  }
+  if (state === 'active') {
+    return <Play size={14} />;
+  }
+  return <CircleDot size={14} />;
+}
+
+export default function CurriculumWeekGrid({
+  weeks,
+  completedDayIds,
+  onSelectDay,
+  selectedDayId,
+}: CurriculumWeekGridProps) {
+  return (
+    <div className="grid gap-4 xl:grid-cols-2">
+      {weeks.map((week, index) => (
+        <motion.section
+          key={week.week}
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: index * 0.03, duration: 0.2 }}
+          className="rounded-2xl border border-slate-700/70 bg-slate-900/70 p-4 backdrop-blur"
+        >
+          <div className="mb-3 flex items-start justify-between gap-3">
+            <div>
+              <p className="text-xs uppercase tracking-[0.16em] text-slate-400">Week {week.week}</p>
+              <h3 className="mt-1 text-sm font-semibold text-white">{week.title}</h3>
+            </div>
+            <span className="rounded-full border border-slate-600 px-2 py-1 text-[11px] text-slate-300">
+              {week.days.filter((day) => completedDayIds.has(day.id)).length}/{week.days.length} done
+            </span>
+          </div>
+
+          <div className="grid gap-2 sm:grid-cols-2">
+            {week.days.map((day) => {
+              const state = getDayState(day, completedDayIds, selectedDayId);
+              return (
+                <button
+                  type="button"
+                  key={day.id}
+                  onClick={() => onSelectDay(day)}
+                  className={`rounded-xl border p-3 text-left transition ${getDayClassName(state)}`}
+                >
+                  <p className="inline-flex items-center gap-1 text-[11px] uppercase tracking-[0.16em]">
+                    <DayIcon state={state} />
+                    {day.id}
+                  </p>
+                  <p className="mt-1 text-sm font-semibold leading-tight">{day.title}</p>
+                  <p className="mt-1 text-xs opacity-80">{day.focus}</p>
+                </button>
+              );
+            })}
+          </div>
+        </motion.section>
+      ))}
+    </div>
+  );
+}

--- a/components/curriculum/CurriculumWeekGrid.tsx
+++ b/components/curriculum/CurriculumWeekGrid.tsx
@@ -3,24 +3,24 @@
 import { motion } from 'framer-motion';
 import { Check, CircleDot, Play } from 'lucide-react';
 
-import type { CurriculumDayTemplate, CurriculumWeekGroup } from '@/types/curriculum';
+import type { CurriculumDay, CurriculumWeekGroup } from '@/types/curriculum';
 
 type CurriculumWeekGridProps = {
   weeks: CurriculumWeekGroup[];
   completedDayIds: Set<string>;
-  onSelectDay: (day: CurriculumDayTemplate) => void;
+  onSelectDay: (day: CurriculumDay) => void;
   selectedDayId?: string | null;
 };
 
 function getDayState(
-  day: CurriculumDayTemplate,
+  day: CurriculumDay,
   completedDayIds: Set<string>,
   selectedDayId: string | null | undefined,
 ): 'completed' | 'active' | 'pending' {
-  if (completedDayIds.has(day.id)) {
+  if (completedDayIds.has(day.key)) {
     return 'completed';
   }
-  if (selectedDayId === day.id) {
+  if (selectedDayId === day.key) {
     return 'active';
   }
   return 'pending';
@@ -68,7 +68,7 @@ export default function CurriculumWeekGrid({
               <h3 className="mt-1 text-sm font-semibold text-white">{week.title}</h3>
             </div>
             <span className="rounded-full border border-slate-600 px-2 py-1 text-[11px] text-slate-300">
-              {week.days.filter((day) => completedDayIds.has(day.id)).length}/{week.days.length} done
+              {week.days.filter((day) => completedDayIds.has(day.key)).length}/{week.days.length} done
             </span>
           </div>
 
@@ -78,13 +78,13 @@ export default function CurriculumWeekGrid({
               return (
                 <button
                   type="button"
-                  key={day.id}
+                  key={day.key}
                   onClick={() => onSelectDay(day)}
                   className={`rounded-xl border p-3 text-left transition ${getDayClassName(state)}`}
                 >
                   <p className="inline-flex items-center gap-1 text-[11px] uppercase tracking-[0.16em]">
                     <DayIcon state={state} />
-                    {day.id}
+                    {day.key}
                   </p>
                   <p className="mt-1 text-sm font-semibold leading-tight">{day.title}</p>
                   <p className="mt-1 text-xs opacity-80">{day.focus}</p>

--- a/components/curriculum/TodayFocusCard.tsx
+++ b/components/curriculum/TodayFocusCard.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { ArrowRight, CheckCircle2, Compass, Sparkles } from 'lucide-react';
+
+import type { CurriculumDayTemplate, CurriculumProgress } from '@/types/curriculum';
+
+type TodayFocusCardProps = {
+  heading: string;
+  progress: CurriculumProgress;
+  nextDay: CurriculumDayTemplate | null;
+  ctaLabel?: string;
+  onCta?: () => void;
+};
+
+export default function TodayFocusCard({
+  heading,
+  progress,
+  nextDay,
+  ctaLabel,
+  onCta,
+}: TodayFocusCardProps) {
+  const progressWidth = `${Math.max(0, Math.min(100, progress.percent))}%`;
+
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 14 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25 }}
+      className="relative overflow-hidden rounded-3xl border border-cyan-400/20 bg-gradient-to-br from-slate-900 via-slate-900 to-slate-950 p-5 shadow-[0_24px_80px_rgba(8,145,178,0.22)]"
+    >
+      <div className="pointer-events-none absolute -top-16 right-0 h-44 w-44 rounded-full bg-cyan-500/20 blur-3xl" />
+      <div className="pointer-events-none absolute -bottom-14 left-10 h-36 w-36 rounded-full bg-blue-500/20 blur-3xl" />
+
+      <div className="relative space-y-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="inline-flex items-center gap-2 text-xs uppercase tracking-[0.22em] text-cyan-200">
+              <Sparkles size={13} />
+              {heading}
+            </p>
+            <h2 className="text-xl font-semibold text-white md:text-2xl">
+              {progress.completedDays}/{progress.totalDays} days completed
+            </h2>
+            <p className="text-sm text-slate-300">Month 1 curriculum execution status</p>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-right">
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-300">Progress</p>
+            <p className="text-2xl font-semibold text-cyan-200">{progress.percent}%</p>
+          </div>
+        </div>
+
+        <div className="h-3 overflow-hidden rounded-full border border-cyan-300/30 bg-slate-950/70">
+          <motion.div
+            initial={{ width: 0 }}
+            animate={{ width: progressWidth }}
+            transition={{ type: 'spring', stiffness: 140, damping: 22 }}
+            className="h-full bg-gradient-to-r from-cyan-400 to-blue-400"
+          />
+        </div>
+
+        {nextDay ? (
+          <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/10 bg-white/5 px-4 py-3">
+            <div>
+              <p className="inline-flex items-center gap-2 text-xs uppercase tracking-[0.15em] text-slate-300">
+                <Compass size={13} />
+                Today Focus
+              </p>
+              <p className="mt-1 text-sm font-medium text-white">
+                {nextDay.id} - {nextDay.title}
+              </p>
+              <p className="text-xs text-slate-300">{nextDay.focus}</p>
+            </div>
+            {ctaLabel && onCta && (
+              <button
+                type="button"
+                onClick={onCta}
+                className="inline-flex items-center gap-2 rounded-xl border border-cyan-300/50 bg-cyan-400/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-cyan-100 transition hover:bg-cyan-400/20"
+              >
+                {ctaLabel}
+                <ArrowRight size={14} />
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-emerald-400/40 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-100">
+            <p className="inline-flex items-center gap-2 font-semibold">
+              <CheckCircle2 size={16} />
+              Month 1 completed
+            </p>
+            <p className="mt-1 text-emerald-100/90">
+              All 24 curriculum days are logged. Continue with Month 2 planning.
+            </p>
+          </div>
+        )}
+      </div>
+    </motion.section>
+  );
+}

--- a/components/curriculum/TodayFocusCard.tsx
+++ b/components/curriculum/TodayFocusCard.tsx
@@ -3,12 +3,12 @@
 import { motion } from 'framer-motion';
 import { ArrowRight, CheckCircle2, Compass, Sparkles } from 'lucide-react';
 
-import type { CurriculumDayTemplate, CurriculumProgress } from '@/types/curriculum';
+import type { CurriculumDay, CurriculumProgress } from '@/types/curriculum';
 
 type TodayFocusCardProps = {
   heading: string;
   progress: CurriculumProgress;
-  nextDay: CurriculumDayTemplate | null;
+  nextDay: CurriculumDay | null;
   ctaLabel?: string;
   onCta?: () => void;
 };
@@ -67,7 +67,7 @@ export default function TodayFocusCard({
                 Today Focus
               </p>
               <p className="mt-1 text-sm font-medium text-white">
-                {nextDay.id} - {nextDay.title}
+                {nextDay.key} - {nextDay.title}
               </p>
               <p className="text-xs text-slate-300">{nextDay.focus}</p>
             </div>

--- a/components/roadmap/ProgressDashboard.tsx
+++ b/components/roadmap/ProgressDashboard.tsx
@@ -1,12 +1,15 @@
 'use client';
 
+import Link from 'next/link';
 import { useMemo } from 'react';
 import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
+import type { CurriculumProgress } from '@/types/curriculum';
 import type { RoadmapItem } from '@/types/roadmap';
 
 type ProgressDashboardProps = {
   items: RoadmapItem[];
+  curriculumProgress: CurriculumProgress;
 };
 
 type ActivityPoint = {
@@ -55,23 +58,20 @@ function getLast14DaysActivity(items: RoadmapItem[]): ActivityPoint[] {
   return days;
 }
 
-export default function ProgressDashboard({ items }: ProgressDashboardProps) {
+export default function ProgressDashboard({ items, curriculumProgress }: ProgressDashboardProps) {
   const metrics = useMemo(() => {
-    const activeItems = items.filter((item) => item.status !== 'done');
+    const activeItems = items.filter((item) => item.status === 'in_progress' || item.status === 'blocked');
     const completedItems = items.filter((item) => item.status === 'done');
-    const overallProgress = items.length > 0
-      ? Math.round(items.reduce((sum, item) => sum + item.progressPercent, 0) / items.length)
-      : 0;
     const plannedHours = items.reduce((sum, item) => sum + (item.planned_hours ?? 0), 0);
     const actualHours = items.reduce((sum, item) => sum + (item.actual_hours ?? 0), 0);
-    const updatedAt = items
-      .map((item) => item.updated_at)
+    const itemUpdates = items.map((item) => item.updated_at);
+    const logUpdates = items.flatMap((item) => item.dailyLogs.map((log) => log.updated_at));
+    const updatedAt = [...itemUpdates, ...logUpdates]
       .sort((left, right) => right.localeCompare(left))[0] ?? null;
 
     return {
       activeCount: activeItems.length,
       completedCount: completedItems.length,
-      overallProgress,
       plannedHours,
       actualHours,
       updatedAt,
@@ -87,28 +87,31 @@ export default function ProgressDashboard({ items }: ProgressDashboardProps) {
     () => last14Days.reduce((sum, entry) => sum + entry.actualHours, 0),
     [last14Days],
   );
+  const hasExecutionData = items.length > 0 || totalEntries > 0;
 
   return (
     <div className="space-y-4">
       <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-        <div className="rounded-2xl border border-slate-700/60 bg-slate-800/60 p-4">
-          <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Overall Progress</p>
-          <p className="mt-2 text-3xl font-bold text-cyan-300">{metrics.overallProgress}%</p>
-          <p className="mt-1 text-xs text-slate-400">
-            {metrics.completedCount} completed / {items.length} total
+        <div className="rounded-2xl border border-cyan-400/30 bg-gradient-to-br from-cyan-500/10 via-slate-900/80 to-slate-900/80 p-4">
+          <p className="text-xs uppercase tracking-[0.2em] text-cyan-100">Month 1 Completion</p>
+          <p className="mt-2 text-3xl font-bold text-cyan-200">
+            {curriculumProgress.completedDays}/{curriculumProgress.totalDays}
           </p>
+          <p className="mt-1 text-xs text-cyan-100/80">{curriculumProgress.percent}% progress</p>
         </div>
         <div className="rounded-2xl border border-slate-700/60 bg-slate-800/60 p-4">
-          <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Active Milestones</p>
-          <p className="mt-2 text-3xl font-bold text-slate-100">{metrics.activeCount}</p>
-          <p className="mt-1 text-xs text-slate-400">Current execution focus</p>
+          <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Milestones Closed</p>
+          <p className="mt-2 text-3xl font-bold text-slate-100">{metrics.completedCount}</p>
+          <p className="mt-1 text-xs text-slate-400">
+            {items.length > 0 ? `${items.length} total milestones` : 'No milestones synced yet'}
+          </p>
         </div>
         <div className="rounded-2xl border border-slate-700/60 bg-slate-800/60 p-4">
           <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Planned vs Actual</p>
           <p className="mt-2 text-3xl font-bold text-slate-100">
             {metrics.actualHours.toFixed(1)}h / {metrics.plannedHours.toFixed(1)}h
           </p>
-          <p className="mt-1 text-xs text-slate-400">Portfolio roadmap scope</p>
+          <p className="mt-1 text-xs text-slate-400">{metrics.activeCount} active milestone(s)</p>
         </div>
         <div className="rounded-2xl border border-slate-700/60 bg-slate-800/60 p-4">
           <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Last Update</p>
@@ -146,6 +149,20 @@ export default function ProgressDashboard({ items }: ProgressDashboardProps) {
             </BarChart>
           </ResponsiveContainer>
         </div>
+        {!hasExecutionData && (
+          <div className="mt-4 rounded-2xl border border-dashed border-cyan-300/40 bg-cyan-500/5 p-4 text-sm text-cyan-100">
+            <p className="font-semibold">No execution logs yet. Month 1 starts at 0/24.</p>
+            <p className="mt-1 text-cyan-100/80">
+              Open admin and create today&apos;s daily log from a curriculum template to begin tracking.
+            </p>
+            <Link
+              href="/admin"
+              className="mt-3 inline-flex rounded-lg border border-cyan-300/50 px-3 py-2 text-xs font-semibold uppercase tracking-[0.15em] text-cyan-100 transition hover:bg-cyan-400/10"
+            >
+              Open Admin
+            </Link>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/components/roadmap/RoadmapHiringView.tsx
+++ b/components/roadmap/RoadmapHiringView.tsx
@@ -2,16 +2,29 @@
 
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import { ArrowLeft, RefreshCcw } from 'lucide-react';
+import { ArrowLeft, CalendarClock, RefreshCcw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { MONTH1 } from '@/content/curriculum/month1';
+import CurriculumDayDrawer from '@/components/curriculum/CurriculumDayDrawer';
+import CurriculumJumpDialog from '@/components/curriculum/CurriculumJumpDialog';
+import TodayFocusCard from '@/components/curriculum/TodayFocusCard';
+import CurriculumWeekGrid from '@/components/curriculum/CurriculumWeekGrid';
 import ArtifactCard from '@/components/roadmap/ArtifactCard';
 import ProgressDashboard from '@/components/roadmap/ProgressDashboard';
 import RoadmapFilters, { type RoadmapFilterValues } from '@/components/roadmap/RoadmapFilters';
 import RoadmapTimeline from '@/components/roadmap/RoadmapTimeline';
 import WeekDetailDrawer from '@/components/roadmap/WeekDetailDrawer';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  computeProgress,
+  detectCompletedDayIds,
+  getNextIncompleteDay,
+  groupByWeek,
+} from '@/lib/curriculum/month1-utils';
 import { fetchPublicRoadmap } from '@/lib/roadmap/queries';
 import { buildWeekGroups } from '@/lib/roadmap/week-utils';
+import type { CurriculumDayTemplate } from '@/types/curriculum';
 import type { RoadmapDataSet, WeekGroup } from '@/types/roadmap';
 
 const DEFAULT_FILTERS: RoadmapFilterValues = {
@@ -66,10 +79,15 @@ function getHeatmapColor(count: number): string {
 export default function RoadmapHiringView() {
   const [filters, setFilters] = useState<RoadmapFilterValues>(DEFAULT_FILTERS);
   const [data, setData] = useState<RoadmapDataSet>({ items: [], phases: [] });
+  const [activeTab, setActiveTab] = useState<'plan' | 'execution'>('plan');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedWeekKey, setSelectedWeekKey] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [selectedCurriculumDay, setSelectedCurriculumDay] = useState<CurriculumDayTemplate | null>(
+    MONTH1[0] ?? null,
+  );
+  const [curriculumDrawerOpen, setCurriculumDrawerOpen] = useState(false);
 
   const loadRoadmap = useCallback(async () => {
     setLoading(true);
@@ -107,139 +125,228 @@ export default function RoadmapHiringView() {
 
   const heatmapCells = useMemo(() => getHeatmapCells(data), [data]);
   const hasHeatmapActivity = heatmapCells.some((cell) => cell.entries > 0);
+  const curriculumWeeks = useMemo(() => groupByWeek(MONTH1), []);
+  const completedDayIds = useMemo(
+    () => detectCompletedDayIds(data.items.flatMap((item) => item.dailyLogs)),
+    [data.items],
+  );
+  const curriculumProgress = useMemo(() => computeProgress(MONTH1, completedDayIds), [completedDayIds]);
+  const nextDay = useMemo(() => getNextIncompleteDay(MONTH1, completedDayIds), [completedDayIds]);
+  const hasExecutionMilestones = data.items.length > 0;
+
+  const openCurriculumDay = (day: CurriculumDayTemplate) => {
+    setSelectedCurriculumDay(day);
+    setCurriculumDrawerOpen(true);
+  };
 
   return (
-    <main className="min-h-screen bg-slate-900 text-slate-100">
-      <div className="mx-auto flex max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6 lg:px-8">
+    <main className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="pointer-events-none fixed inset-x-0 top-0 h-80 bg-[radial-gradient(circle_at_top,rgba(14,116,144,0.32),transparent_65%)]" />
+
+      <div className="relative mx-auto flex max-w-7xl flex-col gap-8 px-4 py-8 sm:px-6 lg:px-8">
         <header className="space-y-4">
           <Link
             href="/"
-            className="inline-flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-2 text-xs uppercase tracking-[0.15em] text-slate-300 transition hover:border-cyan-400/60 hover:text-cyan-300"
+            className="inline-flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-900/70 px-3 py-2 text-xs uppercase tracking-[0.15em] text-slate-300 transition hover:border-cyan-400/60 hover:text-cyan-300"
           >
             <ArrowLeft size={14} />
             Back To Portfolio
           </Link>
-          <div className="rounded-2xl border border-slate-700/60 bg-gradient-to-br from-slate-800/80 via-slate-900 to-slate-900 p-6">
-            <p className="text-xs uppercase tracking-[0.25em] text-cyan-300">Hiring View</p>
-            <h1 className="mt-3 text-3xl font-bold text-white md:text-4xl">Interactive Roadmap</h1>
+          <div className="rounded-3xl border border-cyan-400/20 bg-gradient-to-br from-slate-900/95 via-slate-900/90 to-slate-950 p-6 shadow-[0_26px_90px_rgba(8,145,178,0.2)]">
+            <p className="text-xs uppercase tracking-[0.25em] text-cyan-200">Hiring View</p>
+            <h1 className="mt-3 text-3xl font-bold text-white md:text-4xl">Interactive Roadmap and Execution Hub</h1>
             <p className="mt-3 max-w-3xl text-sm text-slate-300">
-              30-second summary: progress, last 14 days execution pace, key artifacts, and a week-by-week deep dive.
+              30-second summary: month progress, 14-day execution pace, artifacts, and weekly deep dive. Switch to Plan to inspect the full Month 1 curriculum.
             </p>
           </div>
         </header>
 
-        {error && (
-          <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-rose-500/40 bg-rose-900/20 p-4">
-            <p className="text-sm text-rose-200">{error}</p>
-            <button
-              type="button"
-              onClick={() => void loadRoadmap()}
-              className="inline-flex items-center gap-2 rounded-lg border border-rose-300/40 px-3 py-2 text-xs uppercase tracking-[0.15em] text-rose-100 transition hover:bg-rose-900/40"
+        <TodayFocusCard
+          heading="Public Roadmap Focus"
+          progress={curriculumProgress}
+          nextDay={nextDay}
+          ctaLabel={nextDay ? 'Inspect day details' : undefined}
+          onCta={nextDay ? () => openCurriculumDay(nextDay) : undefined}
+        />
+
+        <ProgressDashboard items={data.items} curriculumProgress={curriculumProgress} />
+
+        <Tabs
+          value={activeTab}
+          onValueChange={(value) => setActiveTab(value as 'plan' | 'execution')}
+          className="space-y-4"
+        >
+          <TabsList className="h-auto gap-2 rounded-2xl border border-slate-700/70 bg-slate-900/70 p-1">
+            <TabsTrigger
+              value="plan"
+              className="rounded-xl px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] data-[state=active]:bg-cyan-500/15 data-[state=active]:text-cyan-100"
             >
-              <RefreshCcw size={14} />
-              Retry
-            </button>
-          </div>
-        )}
+              Plan
+            </TabsTrigger>
+            <TabsTrigger
+              value="execution"
+              className="rounded-xl px-4 py-2 text-xs font-semibold uppercase tracking-[0.16em] data-[state=active]:bg-cyan-500/15 data-[state=active]:text-cyan-100"
+            >
+              Execution
+            </TabsTrigger>
+          </TabsList>
 
-        <RoadmapFilters phases={data.phases} value={filters} onChange={setFilters} />
-
-        {loading ? (
-          <div className="rounded-2xl border border-slate-700/60 bg-slate-800/50 p-8">
-            <div className="h-8 w-8 animate-spin rounded-full border-2 border-slate-500 border-t-cyan-300" />
-          </div>
-        ) : (
-          <>
-            <ProgressDashboard items={data.items} />
-
-            <section className="space-y-3">
-              <div className="flex items-center justify-between">
-                <h2 className="text-xl font-semibold text-white">Timeline / Gantt</h2>
-                <p className="text-xs uppercase tracking-[0.15em] text-slate-400">Animated by Framer Motion</p>
+          <TabsContent value="plan" className="space-y-4">
+            <section className="rounded-3xl border border-slate-700/70 bg-slate-900/70 p-4">
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-xs uppercase tracking-[0.18em] text-cyan-200">Month 1 Curriculum</p>
+                  <h2 className="text-xl font-semibold text-white">4 weeks, 6 days per week, 24 execution days</h2>
+                </div>
+                <CurriculumJumpDialog days={MONTH1} onSelectDay={openCurriculumDay} />
               </div>
-              <RoadmapTimeline items={data.items} />
+              <p className="mb-4 text-sm text-slate-300">
+                Plan tab is code-driven and always available, even if external data is empty. Pick a day to inspect build steps, links, and definition of done.
+              </p>
+              <CurriculumWeekGrid
+                weeks={curriculumWeeks}
+                completedDayIds={completedDayIds}
+                onSelectDay={openCurriculumDay}
+                selectedDayId={selectedCurriculumDay?.id ?? null}
+              />
             </section>
+          </TabsContent>
 
-            <section className="space-y-3">
-              <div className="flex items-center justify-between">
-                <h2 className="text-xl font-semibold text-white">Artifacts</h2>
-                <p className="text-xs uppercase tracking-[0.15em] text-slate-400">PR · Demo · Blog · Docs</p>
+          <TabsContent value="execution" className="space-y-5">
+            {error && (
+              <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-rose-500/40 bg-rose-900/20 p-4">
+                <p className="text-sm text-rose-200">{error}</p>
+                <button
+                  type="button"
+                  onClick={() => void loadRoadmap()}
+                  className="inline-flex items-center gap-2 rounded-lg border border-rose-300/40 px-3 py-2 text-xs uppercase tracking-[0.15em] text-rose-100 transition hover:bg-rose-900/40"
+                >
+                  <RefreshCcw size={14} />
+                  Retry
+                </button>
               </div>
-              {featuredArtifacts.length > 0 ? (
-                <div className="grid gap-3 md:grid-cols-2">
-                  {featuredArtifacts.map(({ artifact, roadmapTitle }) => (
-                    <ArtifactCard key={artifact.id} artifact={artifact} roadmapTitle={roadmapTitle} />
-                  ))}
-                </div>
-              ) : (
-                <p className="rounded-2xl border border-slate-700/60 bg-slate-800/60 p-4 text-sm text-slate-300">
-                  No public artifacts published yet.
-                </p>
-              )}
-            </section>
-
-            <section className="space-y-3">
-              <div className="flex items-center justify-between">
-                <h2 className="text-xl font-semibold text-white">Deep Dive By Week</h2>
-                <p className="text-xs uppercase tracking-[0.15em] text-slate-400">Expandable week cards</p>
-              </div>
-              {weekGroups.length > 0 ? (
-                <div className="grid gap-3 md:grid-cols-2">
-                  {weekGroups.map((week, index) => (
-                    <motion.button
-                      type="button"
-                      key={week.key}
-                      initial={{ opacity: 0, y: 12 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={{ delay: index * 0.04, duration: 0.2 }}
-                      onClick={() => {
-                        setSelectedWeekKey(week.key);
-                        setDrawerOpen(true);
-                      }}
-                      className="rounded-xl border border-slate-700/60 bg-slate-800/60 p-4 text-left transition hover:border-cyan-400/40 hover:bg-slate-800"
-                    >
-                      <p className="text-xs uppercase tracking-[0.15em] text-slate-400">{week.key}</p>
-                      <h3 className="mt-1 text-sm font-semibold text-white">{week.label}</h3>
-                      <p className="mt-2 text-xs text-slate-300">
-                        {week.items.length} milestones · {week.totalActualHours.toFixed(1)}h actual / {week.totalPlannedHours.toFixed(1)}h planned
-                      </p>
-                    </motion.button>
-                  ))}
-                </div>
-              ) : (
-                <p className="rounded-2xl border border-slate-700/60 bg-slate-800/60 p-4 text-sm text-slate-300">
-                  No weekly activity available yet.
-                </p>
-              )}
-            </section>
-
-            {hasHeatmapActivity && (
-              <section className="space-y-3">
-                <div className="flex items-center justify-between">
-                  <h2 className="text-xl font-semibold text-white">Activity Heatmap (Optional)</h2>
-                  <p className="text-xs uppercase tracking-[0.15em] text-slate-400">Last 12 weeks</p>
-                </div>
-                <div className="rounded-2xl border border-slate-700/60 bg-slate-800/60 p-4">
-                  <div
-                    className="grid gap-1"
-                    style={{ gridTemplateColumns: 'repeat(14, minmax(0, 1fr))' }}
-                  >
-                    {heatmapCells.map((cell) => (
-                      <span
-                        key={cell.date}
-                        title={`${cell.date}: ${cell.entries} logs`}
-                        className={`h-4 rounded-sm ${getHeatmapColor(cell.entries)}`}
-                      />
-                    ))}
-                  </div>
-                </div>
-              </section>
             )}
-          </>
-        )}
+
+            <RoadmapFilters phases={data.phases} value={filters} onChange={setFilters} />
+
+            {loading ? (
+              <div className="rounded-2xl border border-slate-700/60 bg-slate-800/50 p-8">
+                <div className="h-8 w-8 animate-spin rounded-full border-2 border-slate-500 border-t-cyan-300" />
+              </div>
+            ) : (
+              <>
+                <section className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h2 className="text-xl font-semibold text-white">Timeline / Gantt</h2>
+                    <p className="text-xs uppercase tracking-[0.15em] text-slate-400">Animated by Framer Motion</p>
+                  </div>
+                  {hasExecutionMilestones ? (
+                    <RoadmapTimeline items={data.items} />
+                  ) : (
+                    <div className="rounded-3xl border border-dashed border-cyan-300/40 bg-cyan-400/5 p-6">
+                      <p className="inline-flex items-center gap-2 text-xs uppercase tracking-[0.17em] text-cyan-200">
+                        <CalendarClock size={14} />
+                        Execution feed is empty
+                      </p>
+                      <h3 className="mt-2 text-xl font-semibold text-white">Start logging days to unlock timeline view</h3>
+                      <p className="mt-2 max-w-2xl text-sm text-cyan-100/80">
+                        Progress already tracks 0/24 from curriculum. Open admin and generate today&apos;s daily log from template to populate execution history.
+                      </p>
+                      <Link
+                        href="/admin"
+                        className="mt-4 inline-flex rounded-xl border border-cyan-300/50 px-4 py-2 text-xs font-semibold uppercase tracking-[0.15em] text-cyan-100 transition hover:bg-cyan-400/10"
+                      >
+                        Open Admin Workspace
+                      </Link>
+                    </div>
+                  )}
+                </section>
+
+                <section className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h2 className="text-xl font-semibold text-white">Artifacts</h2>
+                    <p className="text-xs uppercase tracking-[0.15em] text-slate-400">PR - Demo - Blog - Docs</p>
+                  </div>
+                  {featuredArtifacts.length > 0 ? (
+                    <div className="grid gap-3 md:grid-cols-2">
+                      {featuredArtifacts.map(({ artifact, roadmapTitle }) => (
+                        <ArtifactCard key={artifact.id} artifact={artifact} roadmapTitle={roadmapTitle} />
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="rounded-2xl border border-slate-700/60 bg-slate-800/60 p-4 text-sm text-slate-300">
+                      Artifact feed is waiting for first PR/demo/blog link.
+                    </p>
+                  )}
+                </section>
+
+                <section className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h2 className="text-xl font-semibold text-white">Deep Dive By Week</h2>
+                    <p className="text-xs uppercase tracking-[0.15em] text-slate-400">Expandable week cards</p>
+                  </div>
+                  {weekGroups.length > 0 ? (
+                    <div className="grid gap-3 md:grid-cols-2">
+                      {weekGroups.map((week, index) => (
+                        <motion.button
+                          type="button"
+                          key={week.key}
+                          initial={{ opacity: 0, y: 12 }}
+                          animate={{ opacity: 1, y: 0 }}
+                          transition={{ delay: index * 0.04, duration: 0.2 }}
+                          onClick={() => {
+                            setSelectedWeekKey(week.key);
+                            setDrawerOpen(true);
+                          }}
+                          className="rounded-xl border border-slate-700/60 bg-slate-800/60 p-4 text-left transition hover:border-cyan-400/40 hover:bg-slate-800"
+                        >
+                          <p className="text-xs uppercase tracking-[0.15em] text-slate-400">{week.key}</p>
+                          <h3 className="mt-1 text-sm font-semibold text-white">{week.label}</h3>
+                          <p className="mt-2 text-xs text-slate-300">
+                            {week.items.length} milestones - {week.totalActualHours.toFixed(1)}h actual / {week.totalPlannedHours.toFixed(1)}h planned
+                          </p>
+                        </motion.button>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="rounded-2xl border border-slate-700/60 bg-slate-800/60 p-4 text-sm text-slate-300">
+                      Weekly deep dive will appear after the first execution logs are added.
+                    </p>
+                  )}
+                </section>
+
+                {hasHeatmapActivity && (
+                  <section className="space-y-3">
+                    <div className="flex items-center justify-between">
+                      <h2 className="text-xl font-semibold text-white">Activity Heatmap (Optional)</h2>
+                      <p className="text-xs uppercase tracking-[0.15em] text-slate-400">Last 12 weeks</p>
+                    </div>
+                    <div className="rounded-2xl border border-slate-700/60 bg-slate-800/60 p-4">
+                      <div className="grid gap-1" style={{ gridTemplateColumns: 'repeat(14, minmax(0, 1fr))' }}>
+                        {heatmapCells.map((cell) => (
+                          <span
+                            key={cell.date}
+                            title={`${cell.date}: ${cell.entries} logs`}
+                            className={`h-4 rounded-sm ${getHeatmapColor(cell.entries)}`}
+                          />
+                        ))}
+                      </div>
+                    </div>
+                  </section>
+                )}
+              </>
+            )}
+          </TabsContent>
+        </Tabs>
       </div>
 
       <WeekDetailDrawer week={selectedWeek} open={drawerOpen} onOpenChange={setDrawerOpen} />
+      <CurriculumDayDrawer
+        day={selectedCurriculumDay}
+        open={curriculumDrawerOpen}
+        onOpenChange={setCurriculumDrawerOpen}
+        isCompleted={selectedCurriculumDay ? completedDayIds.has(selectedCurriculumDay.id) : false}
+      />
     </main>
   );
 }

--- a/components/roadmap/RoadmapHiringView.tsx
+++ b/components/roadmap/RoadmapHiringView.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/lib/curriculum/month1-utils';
 import { fetchPublicRoadmap } from '@/lib/roadmap/queries';
 import { buildWeekGroups } from '@/lib/roadmap/week-utils';
-import type { CurriculumDayTemplate } from '@/types/curriculum';
+import type { CurriculumDay } from '@/types/curriculum';
 import type { RoadmapDataSet, WeekGroup } from '@/types/roadmap';
 
 const DEFAULT_FILTERS: RoadmapFilterValues = {
@@ -84,7 +84,7 @@ export default function RoadmapHiringView() {
   const [error, setError] = useState<string | null>(null);
   const [selectedWeekKey, setSelectedWeekKey] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const [selectedCurriculumDay, setSelectedCurriculumDay] = useState<CurriculumDayTemplate | null>(
+  const [selectedCurriculumDay, setSelectedCurriculumDay] = useState<CurriculumDay | null>(
     MONTH1[0] ?? null,
   );
   const [curriculumDrawerOpen, setCurriculumDrawerOpen] = useState(false);
@@ -134,7 +134,7 @@ export default function RoadmapHiringView() {
   const nextDay = useMemo(() => getNextIncompleteDay(MONTH1, completedDayIds), [completedDayIds]);
   const hasExecutionMilestones = data.items.length > 0;
 
-  const openCurriculumDay = (day: CurriculumDayTemplate) => {
+  const openCurriculumDay = (day: CurriculumDay) => {
     setSelectedCurriculumDay(day);
     setCurriculumDrawerOpen(true);
   };
@@ -207,7 +207,7 @@ export default function RoadmapHiringView() {
                 weeks={curriculumWeeks}
                 completedDayIds={completedDayIds}
                 onSelectDay={openCurriculumDay}
-                selectedDayId={selectedCurriculumDay?.id ?? null}
+                selectedDayId={selectedCurriculumDay?.key ?? null}
               />
             </section>
           </TabsContent>
@@ -345,7 +345,7 @@ export default function RoadmapHiringView() {
         day={selectedCurriculumDay}
         open={curriculumDrawerOpen}
         onOpenChange={setCurriculumDrawerOpen}
-        isCompleted={selectedCurriculumDay ? completedDayIds.has(selectedCurriculumDay.id) : false}
+        isCompleted={selectedCurriculumDay ? completedDayIds.has(selectedCurriculumDay.key) : false}
       />
     </main>
   );

--- a/content/curriculum/month1.ts
+++ b/content/curriculum/month1.ts
@@ -1,0 +1,582 @@
+import type { CurriculumDayTemplate, CurriculumWeekMilestone } from '@/types/curriculum';
+
+type DayBlueprint = Omit<CurriculumDayTemplate, 'id' | 'week' | 'day' | 'suggestedDate'>;
+
+type WeekBlueprint = {
+  week: number;
+  milestone: CurriculumWeekMilestone;
+  days: DayBlueprint[];
+};
+
+function toIsoDateFromWeekDay(week: number, day: number): string {
+  const start = new Date(Date.UTC(2026, 0, 5));
+  const offset = (week - 1) * 7 + (day - 1);
+  start.setUTCDate(start.getUTCDate() + offset);
+  return start.toISOString().slice(0, 10);
+}
+
+function toCurriculumDayId(week: number, day: number): string {
+  return `W${week}D${day}`;
+}
+
+const WEEK_BLUEPRINTS: WeekBlueprint[] = [
+  {
+    week: 1,
+    milestone: {
+      week: 1,
+      title: 'Week 1 — Tooling Baseline',
+      summary: 'Set project standards, UI primitives, and delivery rhythm for daily execution.',
+    },
+    days: [
+      {
+        title: 'Repo Baseline and DX',
+        focus: 'Dev environment consistency',
+        summary: 'Lock scripts, lint conventions, and release-ready local workflow.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'App Router Architecture', url: 'https://www.youtube.com/results?search_query=nextjs+app+router+architecture' },
+          { label: 'TypeScript Project Setup', url: 'https://www.youtube.com/results?search_query=typescript+project+setup+best+practices' },
+        ],
+        buildSteps: [
+          'Run install/typecheck/lint/build and capture baseline outputs.',
+          'Verify route-level loading behavior for roadmap/admin screens.',
+          'Document local-mode workflow for static export constraints.',
+        ],
+        definitionOfDone: [
+          'All quality commands run green.',
+          'Static export assumptions are documented for future weeks.',
+          'No credentials are hardcoded in code or docs.',
+        ],
+        artifactTargets: ['Setup checklist note', 'Baseline screenshot'],
+      },
+      {
+        title: 'UI Primitive Audit',
+        focus: 'Reusable component quality',
+        summary: 'Review and align card, badge, button, and table patterns for roadmap/admin.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Radix + Tailwind Patterns', url: 'https://www.youtube.com/results?search_query=radix+ui+tailwind+design+system' },
+          { label: 'Design Tokens in Tailwind', url: 'https://www.youtube.com/results?search_query=tailwind+design+tokens+workflow' },
+        ],
+        buildSteps: [
+          'Inspect visual hierarchy, spacing scale, and typography consistency.',
+          'Define premium card style tokens for roadmap/admin surfaces.',
+          'Standardize hover and focus states across controls.',
+        ],
+        definitionOfDone: [
+          'Shared card/button language is visually consistent.',
+          'Interactive controls have clear hover/focus feedback.',
+          'Component usage avoids duplicated ad-hoc styles.',
+        ],
+        artifactTargets: ['UI audit note', 'Before-after comparison'],
+      },
+      {
+        title: 'Motion Baseline',
+        focus: 'Framer Motion system',
+        summary: 'Set spring presets and apply intentional transitions for timeline and cards.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Framer Motion Springs', url: 'https://www.youtube.com/results?search_query=framer+motion+spring+animations' },
+          { label: 'Micro Interactions', url: 'https://www.youtube.com/results?search_query=ui+micro+interactions+framer+motion' },
+        ],
+        buildSteps: [
+          'Create a small set of spring configs: snappy, fluid, heavy.',
+          'Apply staggered entrances to high-level sections.',
+          'Prevent layout shift and keep transitions transform/opacity based.',
+        ],
+        definitionOfDone: [
+          'Key surfaces animate at 60fps without jank.',
+          'Animation timing communicates hierarchy.',
+          'Reduced-motion fallback is respected.',
+        ],
+        artifactTargets: ['Motion clip', 'Animation preset snippet'],
+      },
+      {
+        title: 'Data Shape Contract',
+        focus: 'Roadmap and log data semantics',
+        summary: 'Normalize naming and ensure local-first data behavior remains predictable.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Client Data Modeling', url: 'https://www.youtube.com/results?search_query=frontend+data+modeling+typescript' },
+          { label: 'Local-first UX', url: 'https://www.youtube.com/results?search_query=local+first+web+apps+architecture' },
+        ],
+        buildSteps: [
+          'Validate roadmap and daily log mapping assumptions.',
+          'Define curriculum prefix format W#D# for progress detection.',
+          'Draft helper utilities for progress and next-focus calculations.',
+        ],
+        definitionOfDone: [
+          'Data helpers are deterministic and testable by inspection.',
+          'Progress tracking works without backend connectivity.',
+          'No schema migration is required.',
+        ],
+        artifactTargets: ['Helper API note', 'Progress formula doc'],
+      },
+      {
+        title: 'Interaction Accessibility',
+        focus: 'Keyboard and readable states',
+        summary: 'Ensure roadmap/admin interactions are keyboard-safe and visually clear.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Accessible Admin UI', url: 'https://www.youtube.com/results?search_query=accessible+admin+dashboard+ui' },
+          { label: 'Keyboard Navigation Patterns', url: 'https://www.youtube.com/results?search_query=keyboard+navigation+react+ui' },
+        ],
+        buildSteps: [
+          'Confirm focus rings and tab order for forms and drawers.',
+          'Improve empty-state copy to guide first action.',
+          'Review contrast on gradient and glass surfaces.',
+        ],
+        definitionOfDone: [
+          'Primary workflows complete without pointer input.',
+          'CTA copy is visible and actionable in empty states.',
+          'No unreadable text/background combinations remain.',
+        ],
+        artifactTargets: ['Accessibility pass checklist', 'Keyboard flow gif'],
+      },
+      {
+        title: 'Week 1 Integration Review',
+        focus: 'Baseline readiness',
+        summary: 'Consolidate quality, visuals, and data utilities for week handoff.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Code Review for Frontend', url: 'https://www.youtube.com/results?search_query=frontend+code+review+process' },
+          { label: 'Release Checklist', url: 'https://www.youtube.com/results?search_query=frontend+release+checklist' },
+        ],
+        buildSteps: [
+          'Run full quality gates and verify no regressions.',
+          'Capture visuals for public roadmap and admin baseline.',
+          'Create concise notes for week 2 execution plan.',
+        ],
+        definitionOfDone: [
+          'Quality gates pass cleanly.',
+          'Public and admin states have clear empty/data views.',
+          'Week 2 backlog is actionable.',
+        ],
+        artifactTargets: ['Week 1 recap note', 'Verification output snapshot'],
+      },
+    ],
+  },
+  {
+    week: 2,
+    milestone: {
+      week: 2,
+      title: 'Week 2 — UI Systems and Motion',
+      summary: 'Deliver public roadmap storytelling with filters, timeline depth, and strong interaction design.',
+    },
+    days: [
+      {
+        title: 'Plan vs Execution IA',
+        focus: 'Roadmap information architecture',
+        summary: 'Split public roadmap into fast Plan overview and deep Execution mode.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Dashboard Information Design', url: 'https://www.youtube.com/results?search_query=dashboard+information+architecture' },
+          { label: 'Tabs UX Best Practices', url: 'https://www.youtube.com/results?search_query=tabs+ux+best+practices' },
+        ],
+        buildSteps: [
+          'Implement tabs for Plan and Execution without navigation churn.',
+          'Design summary cards for 30-second hiring read.',
+          'Ensure responsive layout parity on mobile and desktop.',
+        ],
+        definitionOfDone: [
+          'Plan/Execution switch is immediate and understandable.',
+          'Critical status can be read in under 30 seconds.',
+          'Layout remains stable across breakpoints.',
+        ],
+        artifactTargets: ['Roadmap IA screenshot', 'Interaction video'],
+      },
+      {
+        title: 'Timeline/Gantt Refinement',
+        focus: 'Execution readability',
+        summary: 'Improve status signaling, spacing, and hover feedback for timeline bars.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Gantt UX Patterns', url: 'https://www.youtube.com/results?search_query=gantt+chart+ux+patterns' },
+          { label: 'Motion for Dashboards', url: 'https://www.youtube.com/results?search_query=dashboard+animation+principles' },
+        ],
+        buildSteps: [
+          'Tune bar offsets, labels, and status colors for readability.',
+          'Add motion that reinforces chronology rather than decoration.',
+          'Define empty-state fallback for no milestones.',
+        ],
+        definitionOfDone: [
+          'Timeline is readable on first scan.',
+          'Status colors and labels are consistent.',
+          'No-data state has a clear next step.',
+        ],
+        artifactTargets: ['Timeline refinement snapshot', 'Status legend'],
+      },
+      {
+        title: 'Artifact Narrative Layer',
+        focus: 'Proof-of-work storytelling',
+        summary: 'Elevate PR/demo/blog cards to look like enterprise project evidence.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Portfolio Case Study Cards', url: 'https://www.youtube.com/results?search_query=portfolio+case+study+ui+cards' },
+          { label: 'Designing Link Cards', url: 'https://www.youtube.com/results?search_query=link+card+design+patterns' },
+        ],
+        buildSteps: [
+          'Improve card hierarchy: type, title, source milestone, action.',
+          'Add polished hover and action affordances.',
+          'Limit density while preserving scan speed.',
+        ],
+        definitionOfDone: [
+          'Artifacts feel consistent and premium.',
+          'Card CTA behavior is predictable.',
+          'Roadmap context is visible per artifact.',
+        ],
+        artifactTargets: ['Artifact card gallery', 'Component preview'],
+      },
+      {
+        title: 'Search and Filters',
+        focus: 'Fast navigation at scale',
+        summary: 'Improve phase/status filtering and optional day jump interactions.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Command Palette UX', url: 'https://www.youtube.com/results?search_query=cmdk+command+palette+react' },
+          { label: 'Filter UX Heuristics', url: 'https://www.youtube.com/results?search_query=filter+ux+heuristics' },
+        ],
+        buildSteps: [
+          'Harden query + phase + status filters for execution tab.',
+          'Add optional command-jump for curriculum days.',
+          'Preserve context when switching between sections.',
+        ],
+        definitionOfDone: [
+          'Filtering is stable with no unexpected resets.',
+          'Jump-to-day workflow opens correct detail drawer.',
+          'Keyboard interactions remain intact.',
+        ],
+        artifactTargets: ['Filter walkthrough gif', 'Command palette demo'],
+      },
+      {
+        title: 'Responsive QA Sprint',
+        focus: 'Mobile-first hardening',
+        summary: 'Tune spacing and component behavior for small screens and tablets.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Mobile Dashboard Design', url: 'https://www.youtube.com/results?search_query=mobile+dashboard+design+best+practices' },
+          { label: 'Responsive Tailwind Layouts', url: 'https://www.youtube.com/results?search_query=tailwind+responsive+layout+patterns' },
+        ],
+        buildSteps: [
+          'Inspect roadmap/admin key sections in mobile viewport.',
+          'Fix dense card layout and clipped labels.',
+          'Ensure drawers and forms remain usable on small screens.',
+        ],
+        definitionOfDone: [
+          'No critical overflow or clipped content.',
+          'Core actions reachable with thumb-friendly controls.',
+          'Typography hierarchy remains clear on mobile.',
+        ],
+        artifactTargets: ['Mobile QA checklist', 'Before-after mobile shots'],
+      },
+      {
+        title: 'Week 2 Demo Story',
+        focus: 'Hiring-friendly communication',
+        summary: 'Package roadmap improvements into a concise narrative for reviewers.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Product Demo Structure', url: 'https://www.youtube.com/results?search_query=how+to+structure+product+demo' },
+          { label: 'Portfolio Storytelling', url: 'https://www.youtube.com/results?search_query=portfolio+storytelling+for+developers' },
+        ],
+        buildSteps: [
+          'Record short walkthrough for Plan and Execution views.',
+          'Highlight measurable progress and proof links.',
+          'Prepare week 3 admin-focused backlog.',
+        ],
+        definitionOfDone: [
+          'Demo covers value, flow, and evidence.',
+          'Week 3 tasks are prioritized and scoped.',
+          'Artifacts are linked from roadmap.',
+        ],
+        artifactTargets: ['Demo script', 'Walkthrough recording'],
+      },
+    ],
+  },
+  {
+    week: 3,
+    milestone: {
+      week: 3,
+      title: 'Week 3 — Data and Admin Workflows',
+      summary: 'Build repeatable daily execution loops with robust admin tooling and local-first reliability.',
+    },
+    days: [
+      {
+        title: 'Curriculum Data Layer',
+        focus: 'Template-driven execution',
+        summary: 'Model month curriculum as reusable typed data and helper functions.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'TypeScript Data Modeling', url: 'https://www.youtube.com/results?search_query=typescript+data+modeling+patterns' },
+          { label: 'Domain Driven Frontend', url: 'https://www.youtube.com/results?search_query=domain+driven+frontend+architecture' },
+        ],
+        buildSteps: [
+          'Create month1 data source with full day details.',
+          'Add grouping, completion, and progress helpers.',
+          'Expose utilities for both roadmap and admin surfaces.',
+        ],
+        definitionOfDone: [
+          'Single source of truth powers both views.',
+          'Progress computes correctly from W#D# prefixes.',
+          'No backend dependency is required for rendering.',
+        ],
+        artifactTargets: ['Data model diff', 'Utility function notes'],
+      },
+      {
+        title: 'Admin Curriculum Surface',
+        focus: 'Operational execution panel',
+        summary: 'Design week/day control center and rich day details with drawer UX.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Drawer UX Patterns', url: 'https://www.youtube.com/results?search_query=drawer+ux+patterns+web' },
+          { label: 'Admin Panel IA', url: 'https://www.youtube.com/results?search_query=admin+panel+information+architecture' },
+        ],
+        buildSteps: [
+          'Build week grid with completion state indicators.',
+          'Open selected day in Vaul drawer with details.',
+          'Integrate jump-to-day shortcut for faster navigation.',
+        ],
+        definitionOfDone: [
+          'Week/day cards are legible and interactive.',
+          'Drawer surfaces links, steps, and DoD clearly.',
+          'Day selection is reflected across UI state.',
+        ],
+        artifactTargets: ['Admin curriculum screenshot', 'Drawer interaction gif'],
+      },
+      {
+        title: 'One-Click Log Creation',
+        focus: 'Execution automation',
+        summary: 'Generate daily logs from day template and mark completion instantly.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Form Automation UX', url: 'https://www.youtube.com/results?search_query=form+automation+ux+patterns' },
+          { label: 'Supabase CRUD Patterns', url: 'https://www.youtube.com/results?search_query=supabase+crud+best+practices' },
+        ],
+        buildSteps: [
+          'Create template note builder from curriculum details.',
+          'Ensure week milestones exist before daily log insertion.',
+          'Prevent duplicate day creation using title prefix checks.',
+        ],
+        definitionOfDone: [
+          'Click creates a valid daily log row with W#D# prefix.',
+          'Week milestones auto-create when absent.',
+          'Completed badge updates immediately after refresh.',
+        ],
+        artifactTargets: ['Template creation clip', 'Sample daily log output'],
+      },
+      {
+        title: 'Quality and Guardrails',
+        focus: 'Safe admin operations',
+        summary: 'Strengthen validation and user feedback in admin workflows.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Form Validation UX', url: 'https://www.youtube.com/results?search_query=form+validation+ux+best+practices' },
+          { label: 'Resilient Client State', url: 'https://www.youtube.com/results?search_query=resilient+react+state+patterns' },
+        ],
+        buildSteps: [
+          'Add loading states and disabled states for create actions.',
+          'Provide concise success/error feedback for admin actions.',
+          'Keep fallback behavior clean when backend is not configured.',
+        ],
+        definitionOfDone: [
+          'No silent failures on button actions.',
+          'Action feedback is visible and contextual.',
+          'Local mode handles operations without runtime errors.',
+        ],
+        artifactTargets: ['Admin feedback state shots', 'Validation checklist'],
+      },
+      {
+        title: 'Insight Dashboard Polish',
+        focus: 'Progress comprehension',
+        summary: 'Improve progress and activity framing so updates are obvious at a glance.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Data Visualization for Product', url: 'https://www.youtube.com/results?search_query=dashboard+data+visualization+best+practices' },
+          { label: 'Recharts Dashboard Tutorial', url: 'https://www.youtube.com/results?search_query=recharts+dashboard+tutorial' },
+        ],
+        buildSteps: [
+          'Expose completed/total curriculum metrics prominently.',
+          'Tune 14-day activity chart labels and empty messaging.',
+          'Align progress cards between public and admin contexts.',
+        ],
+        definitionOfDone: [
+          'Progress never shows ambiguous 0/0 state.',
+          'Chart remains informative with low activity.',
+          'Today Focus is visible in both screens.',
+        ],
+        artifactTargets: ['Dashboard comparison', 'Metric definition note'],
+      },
+      {
+        title: 'Week 3 Integration Review',
+        focus: 'Execution loop readiness',
+        summary: 'Validate end-to-end daily workflow from planning to logging.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Release QA Checklist', url: 'https://www.youtube.com/results?search_query=frontend+release+qa+checklist' },
+          { label: 'Feature Walkthrough Format', url: 'https://www.youtube.com/results?search_query=feature+walkthrough+best+practice' },
+        ],
+        buildSteps: [
+          'Run full quality pipeline and manual interaction checks.',
+          'Verify curriculum completion detection against existing logs.',
+          'Prepare final week mini-project scope and outcomes.',
+        ],
+        definitionOfDone: [
+          'Roadmap/admin loops are stable.',
+          'All critical acceptance criteria are demonstrable.',
+          'Week 4 goals are clearly prioritized.',
+        ],
+        artifactTargets: ['Week 3 report', 'Verification output snippet'],
+      },
+    ],
+  },
+  {
+    week: 4,
+    milestone: {
+      week: 4,
+      title: 'Week 4 — Titanic Mini Project',
+      summary: 'Ship final integrated experience and present progress as a hiring-ready execution system.',
+    },
+    days: [
+      {
+        title: 'Mini-Project Scope Lock',
+        focus: 'Outcome-first planning',
+        summary: 'Define narrow, demonstrable success criteria for final public/admin release.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'MVP Scoping', url: 'https://www.youtube.com/results?search_query=mvp+scope+product+management' },
+          { label: 'Feature Prioritization', url: 'https://www.youtube.com/results?search_query=feature+prioritization+framework' },
+        ],
+        buildSteps: [
+          'List must-have vs nice-to-have items.',
+          'Lock Definition of Done for release candidate.',
+          'Sequence final implementation tasks by risk.',
+        ],
+        definitionOfDone: [
+          'Scope is documented and frozen for week 4.',
+          'Every task maps to user-visible value.',
+          'Timeline supports predictable delivery.',
+        ],
+        artifactTargets: ['Scope matrix', 'Release backlog'],
+      },
+      {
+        title: 'Public Roadmap Final Pass',
+        focus: 'Hiring-page quality',
+        summary: 'Finalize roadmap visual polish, copy, and scan speed.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Portfolio UX Critique', url: 'https://www.youtube.com/results?search_query=portfolio+ux+critique' },
+          { label: 'Conversion-focused UI Copy', url: 'https://www.youtube.com/results?search_query=ui+copywriting+for+conversion' },
+        ],
+        buildSteps: [
+          'Polish tab labels, card copy, and CTA hierarchy.',
+          'Improve empty-state storytelling with actionable steps.',
+          'Validate visual balance on desktop and mobile.',
+        ],
+        definitionOfDone: [
+          'Public page communicates status in 30 seconds.',
+          'Plan and Execution flows are both production-ready.',
+          'No generic placeholder copy remains.',
+        ],
+        artifactTargets: ['Roadmap final screenshots', 'Copy update note'],
+      },
+      {
+        title: 'Admin Flow Final Pass',
+        focus: 'Operational speed',
+        summary: 'Ensure daily execution updates can be completed in under two minutes.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Admin UX Speed Patterns', url: 'https://www.youtube.com/results?search_query=admin+ux+speed+patterns' },
+          { label: 'Productive Forms Design', url: 'https://www.youtube.com/results?search_query=high+productivity+form+design' },
+        ],
+        buildSteps: [
+          'Optimize day selection to log creation flow.',
+          'Confirm milestone auto-create logic in empty database state.',
+          'Tune feedback messaging and completion badges.',
+        ],
+        definitionOfDone: [
+          'One-click template log flow succeeds reliably.',
+          'Missing milestone case resolves automatically.',
+          'Completion state is immediately visible.',
+        ],
+        artifactTargets: ['Admin flow recording', 'Latency notes'],
+      },
+      {
+        title: 'Cross-View Consistency',
+        focus: 'Design and data coherence',
+        summary: 'Align terminology, status colors, and progress logic across screens.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Design QA Workflow', url: 'https://www.youtube.com/results?search_query=design+qa+workflow+frontend' },
+          { label: 'Consistency in Design Systems', url: 'https://www.youtube.com/results?search_query=design+system+consistency+audit' },
+        ],
+        buildSteps: [
+          'Cross-check labels and metric meaning in roadmap/admin.',
+          'Standardize status badges and card component usage.',
+          'Fix any visual regression introduced during feature work.',
+        ],
+        definitionOfDone: [
+          'No conflicting terms between views.',
+          'Progress metrics are computed the same way everywhere.',
+          'UI language feels like one coherent product.',
+        ],
+        artifactTargets: ['Consistency audit table', 'UI diff'],
+      },
+      {
+        title: 'Hiring Package Assembly',
+        focus: 'Evidence packaging',
+        summary: 'Collect demos, PRs, and concise notes that prove execution discipline.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Engineering Portfolio Presentation', url: 'https://www.youtube.com/results?search_query=engineering+portfolio+presentation' },
+          { label: 'Technical Storytelling', url: 'https://www.youtube.com/results?search_query=technical+storytelling+for+hiring' },
+        ],
+        buildSteps: [
+          'Curate top artifacts from each week.',
+          'Write summary bullets for outcomes and impact.',
+          'Link supporting evidence into roadmap artifacts.',
+        ],
+        definitionOfDone: [
+          'Artifacts map to key capabilities clearly.',
+          'Narrative highlights consistency and delivery pace.',
+          'All links are valid and publicly accessible.',
+        ],
+        artifactTargets: ['Hiring evidence doc', 'Artifact shortlist'],
+      },
+      {
+        title: 'Final Demo and Retrospective',
+        focus: 'Closeout quality',
+        summary: 'Run final verification and capture what worked for Month 2 planning.',
+        plannedHours: 1.5,
+        videoLinks: [
+          { label: 'Retrospective Facilitation', url: 'https://www.youtube.com/results?search_query=engineering+retrospective+techniques' },
+          { label: 'Final Demo Checklist', url: 'https://www.youtube.com/results?search_query=product+demo+final+checklist' },
+        ],
+        buildSteps: [
+          'Run typecheck/lint/build and verify all acceptance criteria.',
+          'Record final walkthrough of roadmap and admin.',
+          'Capture lessons learned and next-month improvements.',
+        ],
+        definitionOfDone: [
+          'Quality pipeline is green.',
+          'Demo clearly shows public + admin value.',
+          'Retrospective produces actionable Month 2 items.',
+        ],
+        artifactTargets: ['Final demo recording', 'Retro notes'],
+      },
+    ],
+  },
+];
+
+export const MONTH1_WEEK_MILESTONES: CurriculumWeekMilestone[] = WEEK_BLUEPRINTS.map((week) => week.milestone);
+
+export const MONTH1: CurriculumDayTemplate[] = WEEK_BLUEPRINTS.flatMap((week) =>
+  week.days.map((day, index) => {
+    const dayNumber = index + 1;
+    return {
+      ...day,
+      id: toCurriculumDayId(week.week, dayNumber),
+      week: week.week,
+      day: dayNumber,
+      suggestedDate: toIsoDateFromWeekDay(week.week, dayNumber),
+    };
+  }),
+);

--- a/content/curriculum/month1.ts
+++ b/content/curriculum/month1.ts
@@ -1,582 +1,232 @@
-import type { CurriculumDayTemplate, CurriculumWeekMilestone } from '@/types/curriculum';
-
-type DayBlueprint = Omit<CurriculumDayTemplate, 'id' | 'week' | 'day' | 'suggestedDate'>;
-
-type WeekBlueprint = {
-  week: number;
-  milestone: CurriculumWeekMilestone;
-  days: DayBlueprint[];
+// content/curriculum/month1.ts
+export type CurriculumDay = {
+  key: string; // "W1D1"
+  week: number; // 1..4
+  day: number; // 1..6
+  title: string; // short
+  focus: "Tooling" | "Python" | "Math" | "Data" | "SQL" | "Project";
+  timeboxHours: number; // 1.0..2.0
+  video: { title: string; url: string; notes?: string }[];
+  build: string[]; // coding tasks
+  dod: string[]; // definition of done
 };
 
-function toIsoDateFromWeekDay(week: number, day: number): string {
-  const start = new Date(Date.UTC(2026, 0, 5));
-  const offset = (week - 1) * 7 + (day - 1);
-  start.setUTCDate(start.getUTCDate() + offset);
-  return start.toISOString().slice(0, 10);
-}
+export const MONTH1: CurriculumDay[] = [
+  // WEEK 1 - Tooling + Git + LA warmup
+  {
+    key: "W1D1", week: 1, day: 1, focus: "Tooling", timeboxHours: 1.5,
+    title: "Shell basics + toolbox repo",
+    video: [
+      { title: "Missing Semester - The Shell", url: "https://missing.csail.mit.edu/2020/course-shell/" }
+    ],
+    build: [
+      "Create toolbox repo structure: scripts/, notes/",
+      "Write cheat-sheet: ls/grep/find/cat/pipes",
+      "Add README: how to run scripts"
+    ],
+    dod: ["1 meaningful commit", "README exists", "cheat-sheet added"]
+  },
+  {
+    key: "W1D2", week: 1, day: 2, focus: "Tooling", timeboxHours: 1.5,
+    title: "Git fundamentals: branch/merge mental model",
+    video: [
+      { title: "Corey Schafer - Git & GitHub", url: "https://www.youtube.com/playlist?list=PL-osiE80TeTuRUfjRe54Eea17-YfnOOAx" }
+    ],
+    build: ["Feature branch workflow locally (branch -> commits -> merge)", ".gitignore cleanup"],
+    dod: ["2 commits (feat + docs)", "branch merged cleanly"]
+  },
+  {
+    key: "W1D3", week: 1, day: 3, focus: "Tooling", timeboxHours: 1.5,
+    title: "Missing Semester: Version Control deepening",
+    video: [
+      { title: "Missing Semester - Version Control", url: "https://missing.csail.mit.edu/2020/version-control/" }
+    ],
+    build: ["Add CONTRIBUTING.md (3 rules)", "Adopt commit convention: feat/fix/docs"],
+    dod: ["CONTRIBUTING.md merged", "commit convention used"]
+  },
+  {
+    key: "W1D4", week: 1, day: 4, focus: "Math", timeboxHours: 1.5,
+    title: "Linear Algebra warmup: vectors + similarity",
+    video: [
+      { title: "3Blue1Brown - Essence of Linear Algebra (1-2)", url: "https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab" }
+    ],
+    build: ["Implement dot, norm, cosine similarity (pure python)", "Add 5 asserts / mini-tests"],
+    dod: ["vec.py exists", "tests pass (asserts)"]
+  },
+  {
+    key: "W1D5", week: 1, day: 5, focus: "Tooling", timeboxHours: 1.5,
+    title: "Debugging + logging habit",
+    video: [
+      { title: "Missing Semester - Debugging & Profiling", url: "https://missing.csail.mit.edu/2020/debugging-profiling/" }
+    ],
+    build: ["Add logging to vec functions", "Write short before/after note (2 paragraphs)"],
+    dod: ["logging outputs meaningful", "note committed"]
+  },
+  {
+    key: "W1D6", week: 1, day: 6, focus: "Project", timeboxHours: 1.0,
+    title: "Ship Week 1 artifact",
+    video: [],
+    build: ["Polish README", "Add screenshots (optional)", "Create artifact entry in admin (repo link)"],
+    dod: ["Week 1 artifact link saved", "repo looks professional"]
+  },
 
-function toCurriculumDayId(week: number, day: number): string {
-  return `W${week}D${day}`;
-}
+  // WEEK 2 - Python engineering (OOP + typing + pytest)
+  {
+    key: "W2D1", week: 2, day: 1, focus: "Python", timeboxHours: 1.5,
+    title: "OOP basics: Milestone + DailyLog domain",
+    video: [
+      { title: "Corey Schafer - Python OOP", url: "https://www.youtube.com/playlist?list=PL-osiE80TeTsqhIuOqKhwlXsIBIdSeYtc" }
+    ],
+    build: ["Create roadmap_core module", "Add classes Milestone/DailyLog + docstrings"],
+    dod: ["Classes implemented", "1 commit"]
+  },
+  {
+    key: "W2D2", week: 2, day: 2, focus: "Python", timeboxHours: 1.5,
+    title: "Typing with mypy",
+    video: [
+      { title: "mypy Getting Started", url: "https://mypy.readthedocs.io/en/stable/getting_started.html" }
+    ],
+    build: ["Add mypy.ini", "Fix typing in 3 files (Optional/List/Dict)"],
+    dod: ["mypy . passes (or tracked TODO list)"]
+  },
+  {
+    key: "W2D3", week: 2, day: 3, focus: "Python", timeboxHours: 1.5,
+    title: "pytest: write tests like a grown-up",
+    video: [
+      { title: "pytest Getting Started", url: "https://docs.pytest.org/en/stable/getting-started.html" }
+    ],
+    build: ["Add tests/ folder", "Write 6 tests (edge-cases)"],
+    dod: ["pytest passes", "tests cover edge cases"]
+  },
+  {
+    key: "W2D4", week: 2, day: 4, focus: "Python", timeboxHours: 1.5,
+    title: "Refactor day: clean code pass",
+    video: [
+      { title: "ArjanCodes - Better Python (selected)", url: "https://github.com/ArjanCodes/betterpython" }
+    ],
+    build: ["Refactor for small functions + naming", "Write refactor-notes.md"],
+    dod: ["Refactor committed", "notes exist"]
+  },
+  {
+    key: "W2D5", week: 2, day: 5, focus: "Math", timeboxHours: 1.5,
+    title: "Matrix multiplication: pure python vs numpy",
+    video: [
+      { title: "3Blue1Brown - Linear transformations", url: "https://www.youtube.com/playlist?list=PLZHQObOWTQDPD3MizzM2xVFitgF8hE_ab" }
+    ],
+    build: ["Implement matmul (pure python)", "Add numpy version + tiny benchmark note"],
+    dod: ["matmul works", "benchmark note committed"]
+  },
+  {
+    key: "W2D6", week: 2, day: 6, focus: "Project", timeboxHours: 1.0,
+    title: "Ship Week 2 artifact",
+    video: [],
+    build: ["Polish roadmap_core README", "Attach artifact link in admin"],
+    dod: ["Artifact saved", "repo readable"]
+  },
 
-const WEEK_BLUEPRINTS: WeekBlueprint[] = [
+  // WEEK 3 - Pandas + SQL + EDA
   {
-    week: 1,
-    milestone: {
-      week: 1,
-      title: 'Week 1 — Tooling Baseline',
-      summary: 'Set project standards, UI primitives, and delivery rhythm for daily execution.',
-    },
-    days: [
-      {
-        title: 'Repo Baseline and DX',
-        focus: 'Dev environment consistency',
-        summary: 'Lock scripts, lint conventions, and release-ready local workflow.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'App Router Architecture', url: 'https://www.youtube.com/results?search_query=nextjs+app+router+architecture' },
-          { label: 'TypeScript Project Setup', url: 'https://www.youtube.com/results?search_query=typescript+project+setup+best+practices' },
-        ],
-        buildSteps: [
-          'Run install/typecheck/lint/build and capture baseline outputs.',
-          'Verify route-level loading behavior for roadmap/admin screens.',
-          'Document local-mode workflow for static export constraints.',
-        ],
-        definitionOfDone: [
-          'All quality commands run green.',
-          'Static export assumptions are documented for future weeks.',
-          'No credentials are hardcoded in code or docs.',
-        ],
-        artifactTargets: ['Setup checklist note', 'Baseline screenshot'],
-      },
-      {
-        title: 'UI Primitive Audit',
-        focus: 'Reusable component quality',
-        summary: 'Review and align card, badge, button, and table patterns for roadmap/admin.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Radix + Tailwind Patterns', url: 'https://www.youtube.com/results?search_query=radix+ui+tailwind+design+system' },
-          { label: 'Design Tokens in Tailwind', url: 'https://www.youtube.com/results?search_query=tailwind+design+tokens+workflow' },
-        ],
-        buildSteps: [
-          'Inspect visual hierarchy, spacing scale, and typography consistency.',
-          'Define premium card style tokens for roadmap/admin surfaces.',
-          'Standardize hover and focus states across controls.',
-        ],
-        definitionOfDone: [
-          'Shared card/button language is visually consistent.',
-          'Interactive controls have clear hover/focus feedback.',
-          'Component usage avoids duplicated ad-hoc styles.',
-        ],
-        artifactTargets: ['UI audit note', 'Before-after comparison'],
-      },
-      {
-        title: 'Motion Baseline',
-        focus: 'Framer Motion system',
-        summary: 'Set spring presets and apply intentional transitions for timeline and cards.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Framer Motion Springs', url: 'https://www.youtube.com/results?search_query=framer+motion+spring+animations' },
-          { label: 'Micro Interactions', url: 'https://www.youtube.com/results?search_query=ui+micro+interactions+framer+motion' },
-        ],
-        buildSteps: [
-          'Create a small set of spring configs: snappy, fluid, heavy.',
-          'Apply staggered entrances to high-level sections.',
-          'Prevent layout shift and keep transitions transform/opacity based.',
-        ],
-        definitionOfDone: [
-          'Key surfaces animate at 60fps without jank.',
-          'Animation timing communicates hierarchy.',
-          'Reduced-motion fallback is respected.',
-        ],
-        artifactTargets: ['Motion clip', 'Animation preset snippet'],
-      },
-      {
-        title: 'Data Shape Contract',
-        focus: 'Roadmap and log data semantics',
-        summary: 'Normalize naming and ensure local-first data behavior remains predictable.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Client Data Modeling', url: 'https://www.youtube.com/results?search_query=frontend+data+modeling+typescript' },
-          { label: 'Local-first UX', url: 'https://www.youtube.com/results?search_query=local+first+web+apps+architecture' },
-        ],
-        buildSteps: [
-          'Validate roadmap and daily log mapping assumptions.',
-          'Define curriculum prefix format W#D# for progress detection.',
-          'Draft helper utilities for progress and next-focus calculations.',
-        ],
-        definitionOfDone: [
-          'Data helpers are deterministic and testable by inspection.',
-          'Progress tracking works without backend connectivity.',
-          'No schema migration is required.',
-        ],
-        artifactTargets: ['Helper API note', 'Progress formula doc'],
-      },
-      {
-        title: 'Interaction Accessibility',
-        focus: 'Keyboard and readable states',
-        summary: 'Ensure roadmap/admin interactions are keyboard-safe and visually clear.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Accessible Admin UI', url: 'https://www.youtube.com/results?search_query=accessible+admin+dashboard+ui' },
-          { label: 'Keyboard Navigation Patterns', url: 'https://www.youtube.com/results?search_query=keyboard+navigation+react+ui' },
-        ],
-        buildSteps: [
-          'Confirm focus rings and tab order for forms and drawers.',
-          'Improve empty-state copy to guide first action.',
-          'Review contrast on gradient and glass surfaces.',
-        ],
-        definitionOfDone: [
-          'Primary workflows complete without pointer input.',
-          'CTA copy is visible and actionable in empty states.',
-          'No unreadable text/background combinations remain.',
-        ],
-        artifactTargets: ['Accessibility pass checklist', 'Keyboard flow gif'],
-      },
-      {
-        title: 'Week 1 Integration Review',
-        focus: 'Baseline readiness',
-        summary: 'Consolidate quality, visuals, and data utilities for week handoff.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Code Review for Frontend', url: 'https://www.youtube.com/results?search_query=frontend+code+review+process' },
-          { label: 'Release Checklist', url: 'https://www.youtube.com/results?search_query=frontend+release+checklist' },
-        ],
-        buildSteps: [
-          'Run full quality gates and verify no regressions.',
-          'Capture visuals for public roadmap and admin baseline.',
-          'Create concise notes for week 2 execution plan.',
-        ],
-        definitionOfDone: [
-          'Quality gates pass cleanly.',
-          'Public and admin states have clear empty/data views.',
-          'Week 2 backlog is actionable.',
-        ],
-        artifactTargets: ['Week 1 recap note', 'Verification output snapshot'],
-      },
+    key: "W3D1", week: 3, day: 1, focus: "Data", timeboxHours: 1.5,
+    title: "Pandas basics: load + inspect + nulls",
+    video: [
+      { title: "Data School - Pandas", url: "https://www.youtube.com/playlist?list=PL5-da3qGB5ICCsgW1MxlZ0Hq8LL5U3u9y" }
     ],
+    build: ["Create eda_00_basics.ipynb", "read_csv/head/describe/isna().sum()"],
+    dod: ["Notebook committed", "basic profiling present"]
   },
   {
-    week: 2,
-    milestone: {
-      week: 2,
-      title: 'Week 2 — UI Systems and Motion',
-      summary: 'Deliver public roadmap storytelling with filters, timeline depth, and strong interaction design.',
-    },
-    days: [
-      {
-        title: 'Plan vs Execution IA',
-        focus: 'Roadmap information architecture',
-        summary: 'Split public roadmap into fast Plan overview and deep Execution mode.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Dashboard Information Design', url: 'https://www.youtube.com/results?search_query=dashboard+information+architecture' },
-          { label: 'Tabs UX Best Practices', url: 'https://www.youtube.com/results?search_query=tabs+ux+best+practices' },
-        ],
-        buildSteps: [
-          'Implement tabs for Plan and Execution without navigation churn.',
-          'Design summary cards for 30-second hiring read.',
-          'Ensure responsive layout parity on mobile and desktop.',
-        ],
-        definitionOfDone: [
-          'Plan/Execution switch is immediate and understandable.',
-          'Critical status can be read in under 30 seconds.',
-          'Layout remains stable across breakpoints.',
-        ],
-        artifactTargets: ['Roadmap IA screenshot', 'Interaction video'],
-      },
-      {
-        title: 'Timeline/Gantt Refinement',
-        focus: 'Execution readability',
-        summary: 'Improve status signaling, spacing, and hover feedback for timeline bars.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Gantt UX Patterns', url: 'https://www.youtube.com/results?search_query=gantt+chart+ux+patterns' },
-          { label: 'Motion for Dashboards', url: 'https://www.youtube.com/results?search_query=dashboard+animation+principles' },
-        ],
-        buildSteps: [
-          'Tune bar offsets, labels, and status colors for readability.',
-          'Add motion that reinforces chronology rather than decoration.',
-          'Define empty-state fallback for no milestones.',
-        ],
-        definitionOfDone: [
-          'Timeline is readable on first scan.',
-          'Status colors and labels are consistent.',
-          'No-data state has a clear next step.',
-        ],
-        artifactTargets: ['Timeline refinement snapshot', 'Status legend'],
-      },
-      {
-        title: 'Artifact Narrative Layer',
-        focus: 'Proof-of-work storytelling',
-        summary: 'Elevate PR/demo/blog cards to look like enterprise project evidence.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Portfolio Case Study Cards', url: 'https://www.youtube.com/results?search_query=portfolio+case+study+ui+cards' },
-          { label: 'Designing Link Cards', url: 'https://www.youtube.com/results?search_query=link+card+design+patterns' },
-        ],
-        buildSteps: [
-          'Improve card hierarchy: type, title, source milestone, action.',
-          'Add polished hover and action affordances.',
-          'Limit density while preserving scan speed.',
-        ],
-        definitionOfDone: [
-          'Artifacts feel consistent and premium.',
-          'Card CTA behavior is predictable.',
-          'Roadmap context is visible per artifact.',
-        ],
-        artifactTargets: ['Artifact card gallery', 'Component preview'],
-      },
-      {
-        title: 'Search and Filters',
-        focus: 'Fast navigation at scale',
-        summary: 'Improve phase/status filtering and optional day jump interactions.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Command Palette UX', url: 'https://www.youtube.com/results?search_query=cmdk+command+palette+react' },
-          { label: 'Filter UX Heuristics', url: 'https://www.youtube.com/results?search_query=filter+ux+heuristics' },
-        ],
-        buildSteps: [
-          'Harden query + phase + status filters for execution tab.',
-          'Add optional command-jump for curriculum days.',
-          'Preserve context when switching between sections.',
-        ],
-        definitionOfDone: [
-          'Filtering is stable with no unexpected resets.',
-          'Jump-to-day workflow opens correct detail drawer.',
-          'Keyboard interactions remain intact.',
-        ],
-        artifactTargets: ['Filter walkthrough gif', 'Command palette demo'],
-      },
-      {
-        title: 'Responsive QA Sprint',
-        focus: 'Mobile-first hardening',
-        summary: 'Tune spacing and component behavior for small screens and tablets.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Mobile Dashboard Design', url: 'https://www.youtube.com/results?search_query=mobile+dashboard+design+best+practices' },
-          { label: 'Responsive Tailwind Layouts', url: 'https://www.youtube.com/results?search_query=tailwind+responsive+layout+patterns' },
-        ],
-        buildSteps: [
-          'Inspect roadmap/admin key sections in mobile viewport.',
-          'Fix dense card layout and clipped labels.',
-          'Ensure drawers and forms remain usable on small screens.',
-        ],
-        definitionOfDone: [
-          'No critical overflow or clipped content.',
-          'Core actions reachable with thumb-friendly controls.',
-          'Typography hierarchy remains clear on mobile.',
-        ],
-        artifactTargets: ['Mobile QA checklist', 'Before-after mobile shots'],
-      },
-      {
-        title: 'Week 2 Demo Story',
-        focus: 'Hiring-friendly communication',
-        summary: 'Package roadmap improvements into a concise narrative for reviewers.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Product Demo Structure', url: 'https://www.youtube.com/results?search_query=how+to+structure+product+demo' },
-          { label: 'Portfolio Storytelling', url: 'https://www.youtube.com/results?search_query=portfolio+storytelling+for+developers' },
-        ],
-        buildSteps: [
-          'Record short walkthrough for Plan and Execution views.',
-          'Highlight measurable progress and proof links.',
-          'Prepare week 3 admin-focused backlog.',
-        ],
-        definitionOfDone: [
-          'Demo covers value, flow, and evidence.',
-          'Week 3 tasks are prioritized and scoped.',
-          'Artifacts are linked from roadmap.',
-        ],
-        artifactTargets: ['Demo script', 'Walkthrough recording'],
-      },
+    key: "W3D2", week: 3, day: 2, focus: "Data", timeboxHours: 1.5,
+    title: "Cleaning pipeline: fillna strategy",
+    video: [
+      { title: "Data School - Groupby/cleaning videos (selected)", url: "https://www.youtube.com/playlist?list=PL5-da3qGB5ICCsgW1MxlZ0Hq8LL5U3u9y" }
     ],
+    build: ["Write clean_data(df) function", "median/mode fill strategy"],
+    dod: ["clean_data used in notebook", "explanation added"]
   },
   {
-    week: 3,
-    milestone: {
-      week: 3,
-      title: 'Week 3 — Data and Admin Workflows',
-      summary: 'Build repeatable daily execution loops with robust admin tooling and local-first reliability.',
-    },
-    days: [
-      {
-        title: 'Curriculum Data Layer',
-        focus: 'Template-driven execution',
-        summary: 'Model month curriculum as reusable typed data and helper functions.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'TypeScript Data Modeling', url: 'https://www.youtube.com/results?search_query=typescript+data+modeling+patterns' },
-          { label: 'Domain Driven Frontend', url: 'https://www.youtube.com/results?search_query=domain+driven+frontend+architecture' },
-        ],
-        buildSteps: [
-          'Create month1 data source with full day details.',
-          'Add grouping, completion, and progress helpers.',
-          'Expose utilities for both roadmap and admin surfaces.',
-        ],
-        definitionOfDone: [
-          'Single source of truth powers both views.',
-          'Progress computes correctly from W#D# prefixes.',
-          'No backend dependency is required for rendering.',
-        ],
-        artifactTargets: ['Data model diff', 'Utility function notes'],
-      },
-      {
-        title: 'Admin Curriculum Surface',
-        focus: 'Operational execution panel',
-        summary: 'Design week/day control center and rich day details with drawer UX.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Drawer UX Patterns', url: 'https://www.youtube.com/results?search_query=drawer+ux+patterns+web' },
-          { label: 'Admin Panel IA', url: 'https://www.youtube.com/results?search_query=admin+panel+information+architecture' },
-        ],
-        buildSteps: [
-          'Build week grid with completion state indicators.',
-          'Open selected day in Vaul drawer with details.',
-          'Integrate jump-to-day shortcut for faster navigation.',
-        ],
-        definitionOfDone: [
-          'Week/day cards are legible and interactive.',
-          'Drawer surfaces links, steps, and DoD clearly.',
-          'Day selection is reflected across UI state.',
-        ],
-        artifactTargets: ['Admin curriculum screenshot', 'Drawer interaction gif'],
-      },
-      {
-        title: 'One-Click Log Creation',
-        focus: 'Execution automation',
-        summary: 'Generate daily logs from day template and mark completion instantly.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Form Automation UX', url: 'https://www.youtube.com/results?search_query=form+automation+ux+patterns' },
-          { label: 'Supabase CRUD Patterns', url: 'https://www.youtube.com/results?search_query=supabase+crud+best+practices' },
-        ],
-        buildSteps: [
-          'Create template note builder from curriculum details.',
-          'Ensure week milestones exist before daily log insertion.',
-          'Prevent duplicate day creation using title prefix checks.',
-        ],
-        definitionOfDone: [
-          'Click creates a valid daily log row with W#D# prefix.',
-          'Week milestones auto-create when absent.',
-          'Completed badge updates immediately after refresh.',
-        ],
-        artifactTargets: ['Template creation clip', 'Sample daily log output'],
-      },
-      {
-        title: 'Quality and Guardrails',
-        focus: 'Safe admin operations',
-        summary: 'Strengthen validation and user feedback in admin workflows.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Form Validation UX', url: 'https://www.youtube.com/results?search_query=form+validation+ux+best+practices' },
-          { label: 'Resilient Client State', url: 'https://www.youtube.com/results?search_query=resilient+react+state+patterns' },
-        ],
-        buildSteps: [
-          'Add loading states and disabled states for create actions.',
-          'Provide concise success/error feedback for admin actions.',
-          'Keep fallback behavior clean when backend is not configured.',
-        ],
-        definitionOfDone: [
-          'No silent failures on button actions.',
-          'Action feedback is visible and contextual.',
-          'Local mode handles operations without runtime errors.',
-        ],
-        artifactTargets: ['Admin feedback state shots', 'Validation checklist'],
-      },
-      {
-        title: 'Insight Dashboard Polish',
-        focus: 'Progress comprehension',
-        summary: 'Improve progress and activity framing so updates are obvious at a glance.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Data Visualization for Product', url: 'https://www.youtube.com/results?search_query=dashboard+data+visualization+best+practices' },
-          { label: 'Recharts Dashboard Tutorial', url: 'https://www.youtube.com/results?search_query=recharts+dashboard+tutorial' },
-        ],
-        buildSteps: [
-          'Expose completed/total curriculum metrics prominently.',
-          'Tune 14-day activity chart labels and empty messaging.',
-          'Align progress cards between public and admin contexts.',
-        ],
-        definitionOfDone: [
-          'Progress never shows ambiguous 0/0 state.',
-          'Chart remains informative with low activity.',
-          'Today Focus is visible in both screens.',
-        ],
-        artifactTargets: ['Dashboard comparison', 'Metric definition note'],
-      },
-      {
-        title: 'Week 3 Integration Review',
-        focus: 'Execution loop readiness',
-        summary: 'Validate end-to-end daily workflow from planning to logging.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Release QA Checklist', url: 'https://www.youtube.com/results?search_query=frontend+release+qa+checklist' },
-          { label: 'Feature Walkthrough Format', url: 'https://www.youtube.com/results?search_query=feature+walkthrough+best+practice' },
-        ],
-        buildSteps: [
-          'Run full quality pipeline and manual interaction checks.',
-          'Verify curriculum completion detection against existing logs.',
-          'Prepare final week mini-project scope and outcomes.',
-        ],
-        definitionOfDone: [
-          'Roadmap/admin loops are stable.',
-          'All critical acceptance criteria are demonstrable.',
-          'Week 4 goals are clearly prioritized.',
-        ],
-        artifactTargets: ['Week 3 report', 'Verification output snippet'],
-      },
+    key: "W3D3", week: 3, day: 3, focus: "SQL", timeboxHours: 1.5,
+    title: "SQL basics: SELECT/WHERE/ORDER/LIMIT",
+    video: [
+      { title: "Kaggle - Intro to SQL", url: "https://www.kaggle.com/learn/intro-to-sql" }
     ],
+    build: ["Solve lessons 1-2", "Write sql.md with 10 queries"],
+    dod: ["sql.md committed", "exercises completed"]
   },
   {
-    week: 4,
-    milestone: {
-      week: 4,
-      title: 'Week 4 — Titanic Mini Project',
-      summary: 'Ship final integrated experience and present progress as a hiring-ready execution system.',
-    },
-    days: [
-      {
-        title: 'Mini-Project Scope Lock',
-        focus: 'Outcome-first planning',
-        summary: 'Define narrow, demonstrable success criteria for final public/admin release.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'MVP Scoping', url: 'https://www.youtube.com/results?search_query=mvp+scope+product+management' },
-          { label: 'Feature Prioritization', url: 'https://www.youtube.com/results?search_query=feature+prioritization+framework' },
-        ],
-        buildSteps: [
-          'List must-have vs nice-to-have items.',
-          'Lock Definition of Done for release candidate.',
-          'Sequence final implementation tasks by risk.',
-        ],
-        definitionOfDone: [
-          'Scope is documented and frozen for week 4.',
-          'Every task maps to user-visible value.',
-          'Timeline supports predictable delivery.',
-        ],
-        artifactTargets: ['Scope matrix', 'Release backlog'],
-      },
-      {
-        title: 'Public Roadmap Final Pass',
-        focus: 'Hiring-page quality',
-        summary: 'Finalize roadmap visual polish, copy, and scan speed.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Portfolio UX Critique', url: 'https://www.youtube.com/results?search_query=portfolio+ux+critique' },
-          { label: 'Conversion-focused UI Copy', url: 'https://www.youtube.com/results?search_query=ui+copywriting+for+conversion' },
-        ],
-        buildSteps: [
-          'Polish tab labels, card copy, and CTA hierarchy.',
-          'Improve empty-state storytelling with actionable steps.',
-          'Validate visual balance on desktop and mobile.',
-        ],
-        definitionOfDone: [
-          'Public page communicates status in 30 seconds.',
-          'Plan and Execution flows are both production-ready.',
-          'No generic placeholder copy remains.',
-        ],
-        artifactTargets: ['Roadmap final screenshots', 'Copy update note'],
-      },
-      {
-        title: 'Admin Flow Final Pass',
-        focus: 'Operational speed',
-        summary: 'Ensure daily execution updates can be completed in under two minutes.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Admin UX Speed Patterns', url: 'https://www.youtube.com/results?search_query=admin+ux+speed+patterns' },
-          { label: 'Productive Forms Design', url: 'https://www.youtube.com/results?search_query=high+productivity+form+design' },
-        ],
-        buildSteps: [
-          'Optimize day selection to log creation flow.',
-          'Confirm milestone auto-create logic in empty database state.',
-          'Tune feedback messaging and completion badges.',
-        ],
-        definitionOfDone: [
-          'One-click template log flow succeeds reliably.',
-          'Missing milestone case resolves automatically.',
-          'Completion state is immediately visible.',
-        ],
-        artifactTargets: ['Admin flow recording', 'Latency notes'],
-      },
-      {
-        title: 'Cross-View Consistency',
-        focus: 'Design and data coherence',
-        summary: 'Align terminology, status colors, and progress logic across screens.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Design QA Workflow', url: 'https://www.youtube.com/results?search_query=design+qa+workflow+frontend' },
-          { label: 'Consistency in Design Systems', url: 'https://www.youtube.com/results?search_query=design+system+consistency+audit' },
-        ],
-        buildSteps: [
-          'Cross-check labels and metric meaning in roadmap/admin.',
-          'Standardize status badges and card component usage.',
-          'Fix any visual regression introduced during feature work.',
-        ],
-        definitionOfDone: [
-          'No conflicting terms between views.',
-          'Progress metrics are computed the same way everywhere.',
-          'UI language feels like one coherent product.',
-        ],
-        artifactTargets: ['Consistency audit table', 'UI diff'],
-      },
-      {
-        title: 'Hiring Package Assembly',
-        focus: 'Evidence packaging',
-        summary: 'Collect demos, PRs, and concise notes that prove execution discipline.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Engineering Portfolio Presentation', url: 'https://www.youtube.com/results?search_query=engineering+portfolio+presentation' },
-          { label: 'Technical Storytelling', url: 'https://www.youtube.com/results?search_query=technical+storytelling+for+hiring' },
-        ],
-        buildSteps: [
-          'Curate top artifacts from each week.',
-          'Write summary bullets for outcomes and impact.',
-          'Link supporting evidence into roadmap artifacts.',
-        ],
-        definitionOfDone: [
-          'Artifacts map to key capabilities clearly.',
-          'Narrative highlights consistency and delivery pace.',
-          'All links are valid and publicly accessible.',
-        ],
-        artifactTargets: ['Hiring evidence doc', 'Artifact shortlist'],
-      },
-      {
-        title: 'Final Demo and Retrospective',
-        focus: 'Closeout quality',
-        summary: 'Run final verification and capture what worked for Month 2 planning.',
-        plannedHours: 1.5,
-        videoLinks: [
-          { label: 'Retrospective Facilitation', url: 'https://www.youtube.com/results?search_query=engineering+retrospective+techniques' },
-          { label: 'Final Demo Checklist', url: 'https://www.youtube.com/results?search_query=product+demo+final+checklist' },
-        ],
-        buildSteps: [
-          'Run typecheck/lint/build and verify all acceptance criteria.',
-          'Record final walkthrough of roadmap and admin.',
-          'Capture lessons learned and next-month improvements.',
-        ],
-        definitionOfDone: [
-          'Quality pipeline is green.',
-          'Demo clearly shows public + admin value.',
-          'Retrospective produces actionable Month 2 items.',
-        ],
-        artifactTargets: ['Final demo recording', 'Retro notes'],
-      },
+    key: "W3D4", week: 3, day: 4, focus: "SQL", timeboxHours: 1.5,
+    title: "SQL: JOIN + GROUP BY",
+    video: [
+      { title: "Kaggle - Intro/Advanced SQL (JOIN/GROUP BY)", url: "https://www.kaggle.com/learn/intro-to-sql" }
     ],
+    build: ["Write 5 JOIN/GROUP BY examples with comments"],
+    dod: ["5 queries committed", "each has comment"]
+  },
+  {
+    key: "W3D5", week: 3, day: 5, focus: "Data", timeboxHours: 1.5,
+    title: "Distributions: hist + insights",
+    video: [
+      { title: "StatQuest - Statistics playlist (selected)", url: "https://www.youtube.com/playlist?list=PLblh5JKOoLUK0FLuzwntyYI10UQFUhsY9" }
+    ],
+    build: ["2 hist + 2 relationship plots", "Write 5 insight sentences"],
+    dod: ["eda_01_distributions.ipynb committed", "insights included"]
+  },
+  {
+    key: "W3D6", week: 3, day: 6, focus: "Project", timeboxHours: 1.0,
+    title: "Ship Week 3 artifact",
+    video: [],
+    build: ["Bundle notebooks + sql notes", "Add artifact link"],
+    dod: ["Artifact saved", "repo structure clean"]
+  },
+
+  // WEEK 4 - Titanic mini-project
+  {
+    key: "W4D1", week: 4, day: 1, focus: "Project", timeboxHours: 1.5,
+    title: "Titanic setup: target + split mindset",
+    video: [
+      { title: "Kaggle Titanic page + notebooks", url: "https://www.kaggle.com/competitions/titanic" }
+    ],
+    build: ["titanic_00_setup.ipynb", "Define target, basic preprocessing"],
+    dod: ["Notebook committed"]
+  },
+  {
+    key: "W4D2", week: 4, day: 2, focus: "Project", timeboxHours: 1.5,
+    title: "Baseline model: logistic regression",
+    video: [
+      { title: "StatQuest - Train/Test & Overfitting (selected)", url: "https://www.youtube.com/playlist?list=PLblh5JKOoLUK0FLuzwntyYI10UQFUhsY9" }
+    ],
+    build: ["Train baseline model", "Log initial score"],
+    dod: ["Score recorded", "baseline committed"]
+  },
+  {
+    key: "W4D3", week: 4, day: 3, focus: "Project", timeboxHours: 1.5,
+    title: "Feature engineering: 2 features",
+    video: [
+      { title: "Data School - Feature engineering style videos", url: "https://www.youtube.com/playlist?list=PL5-da3qGB5ICCsgW1MxlZ0Hq8LL5U3u9y" }
+    ],
+    build: ["Add family_size, title extraction (or similar)", "Compare vs baseline"],
+    dod: ["Comparison table committed"]
+  },
+  {
+    key: "W4D4", week: 4, day: 4, focus: "Project", timeboxHours: 1.5,
+    title: "Evaluation: confusion matrix + explain metric",
+    video: [
+      { title: "StatQuest - metrics (selected)", url: "https://www.youtube.com/playlist?list=PLblh5JKOoLUK0FLuzwntyYI10UQFUhsY9" }
+    ],
+    build: ["Add confusion matrix + brief explanation"],
+    dod: ["Evaluation notebook committed"]
+  },
+  {
+    key: "W4D5", week: 4, day: 5, focus: "Project", timeboxHours: 1.5,
+    title: "Write report + clean repo structure",
+    video: [],
+    build: ["reports/titanic_report.md", "repo folders: notebooks/src/reports"],
+    dod: ["report readable", "reproduce steps in README"]
+  },
+  {
+    key: "W4D6", week: 4, day: 6, focus: "Project", timeboxHours: 1.0,
+    title: "Ship Week 4 artifact: Kaggle submission + links",
+    video: [],
+    build: ["Make a Kaggle submission", "Add artifact: Kaggle + repo + report links"],
+    dod: ["Kaggle link saved as artifact", "final repo polished"]
   },
 ];
-
-export const MONTH1_WEEK_MILESTONES: CurriculumWeekMilestone[] = WEEK_BLUEPRINTS.map((week) => week.milestone);
-
-export const MONTH1: CurriculumDayTemplate[] = WEEK_BLUEPRINTS.flatMap((week) =>
-  week.days.map((day, index) => {
-    const dayNumber = index + 1;
-    return {
-      ...day,
-      id: toCurriculumDayId(week.week, dayNumber),
-      week: week.week,
-      day: dayNumber,
-      suggestedDate: toIsoDateFromWeekDay(week.week, dayNumber),
-    };
-  }),
-);

--- a/lib/curriculum/month1-utils.ts
+++ b/lib/curriculum/month1-utils.ts
@@ -1,0 +1,169 @@
+import { MONTH1, MONTH1_WEEK_MILESTONES } from '@/content/curriculum/month1';
+import type {
+  CurriculumDayTemplate,
+  CurriculumProgress,
+  CurriculumWeekGroup,
+} from '@/types/curriculum';
+import type { DailyLogRow, RoadmapItem, RoadmapItemInsert, RoadmapStatus } from '@/types/roadmap';
+
+const CURRICULUM_PREFIX_PATTERN = /\bW([1-4])D([1-6])\b/i;
+
+export function toCurriculumDayId(week: number, day: number): string {
+  return `W${week}D${day}`;
+}
+
+export function groupByWeek(days: CurriculumDayTemplate[] = MONTH1): CurriculumWeekGroup[] {
+  const weekMap = new Map<number, CurriculumDayTemplate[]>();
+
+  for (const day of days) {
+    const values = weekMap.get(day.week) ?? [];
+    values.push(day);
+    weekMap.set(day.week, values);
+  }
+
+  return Array.from(weekMap.entries())
+    .sort((left, right) => left[0] - right[0])
+    .map(([week, values]) => {
+      const milestoneTitle = MONTH1_WEEK_MILESTONES.find((milestone) => milestone.week === week)?.title ?? `Week ${week}`;
+      return {
+        week,
+        title: milestoneTitle,
+        days: values.sort((left, right) => left.day - right.day),
+      };
+    });
+}
+
+export function parseCurriculumPrefix(input: string): string | null {
+  const result = input.match(CURRICULUM_PREFIX_PATTERN);
+  if (!result) {
+    return null;
+  }
+  const week = Number(result[1]);
+  const day = Number(result[2]);
+  if (!Number.isFinite(week) || !Number.isFinite(day)) {
+    return null;
+  }
+  return toCurriculumDayId(week, day);
+}
+
+export function detectCompletedDayIds(logs: DailyLogRow[]): Set<string> {
+  const completed = new Set<string>();
+  for (const log of logs) {
+    const prefix = parseCurriculumPrefix(log.title);
+    if (prefix) {
+      completed.add(prefix);
+    }
+  }
+  return completed;
+}
+
+export function computeProgress(
+  days: CurriculumDayTemplate[],
+  completedDayIds: Set<string>,
+): CurriculumProgress {
+  const totalDays = days.length;
+  const completedDays = days.reduce(
+    (count, day) => count + (completedDayIds.has(day.id) ? 1 : 0),
+    0,
+  );
+  const percent = totalDays > 0 ? Math.round((completedDays / totalDays) * 100) : 0;
+
+  return {
+    completedDays,
+    totalDays,
+    percent,
+  };
+}
+
+export function getNextIncompleteDay(
+  days: CurriculumDayTemplate[],
+  completedDayIds: Set<string>,
+): CurriculumDayTemplate | null {
+  for (const day of days) {
+    if (!completedDayIds.has(day.id)) {
+      return day;
+    }
+  }
+  return null;
+}
+
+export function buildTemplateDailyLog(day: CurriculumDayTemplate): {
+  title: string;
+  notes: string;
+  plannedHours: number;
+} {
+  const links = day.videoLinks.map((link) => `- ${link.label}: ${link.url}`);
+  const buildSteps = day.buildSteps.map((step, index) => `${index + 1}. ${step}`);
+  const definitionOfDone = day.definitionOfDone.map((item, index) => `${index + 1}. ${item}`);
+
+  const notes = [
+    `Focus: ${day.focus}`,
+    `Summary: ${day.summary}`,
+    '',
+    'Video Links:',
+    ...links,
+    '',
+    'Build Steps:',
+    ...buildSteps,
+    '',
+    'Definition of Done:',
+    ...definitionOfDone,
+    '',
+    `Artifact Targets: ${day.artifactTargets.join(', ')}`,
+  ].join('\n');
+
+  return {
+    title: `${day.id} — ${day.title}`,
+    notes,
+    plannedHours: day.plannedHours,
+  };
+}
+
+function toStatus(week: number): RoadmapStatus {
+  if (week === 1) {
+    return 'in_progress';
+  }
+  return 'planned';
+}
+
+export function getWeekMilestoneInsert(
+  week: number,
+  userId: string,
+  sortOrder: number,
+): RoadmapItemInsert {
+  const milestone = MONTH1_WEEK_MILESTONES.find((value) => value.week === week);
+  if (!milestone) {
+    throw new Error(`Week milestone not found: ${week}`);
+  }
+
+  const days = MONTH1.filter((day) => day.week === week);
+  const startDate = days[0]?.suggestedDate ?? new Date().toISOString().slice(0, 10);
+  const endDate = days[days.length - 1]?.suggestedDate ?? startDate;
+  const plannedHours = days.reduce((sum, day) => sum + day.plannedHours, 0);
+
+  return {
+    user_id: userId,
+    title: milestone.title,
+    summary: milestone.summary,
+    phase: 'Month 1 Curriculum',
+    status: toStatus(week),
+    planned_hours: plannedHours,
+    actual_hours: 0,
+    start_date: startDate,
+    end_date: endDate,
+    is_public: true,
+    sort_order: sortOrder,
+  };
+}
+
+export function findWeekMilestone(items: RoadmapItem[], week: number): RoadmapItem | null {
+  const strictPrefix = `Week ${week} —`;
+  const fallbackPrefix = `W${week}`;
+
+  for (const item of items) {
+    if (item.title.startsWith(strictPrefix) || item.title.startsWith(fallbackPrefix)) {
+      return item;
+    }
+  }
+  return null;
+}

--- a/types/curriculum.ts
+++ b/types/curriculum.ts
@@ -1,0 +1,37 @@
+export interface CurriculumResourceLink {
+  label: string;
+  url: string;
+}
+
+export interface CurriculumDayTemplate {
+  id: string;
+  week: number;
+  day: number;
+  suggestedDate: string;
+  title: string;
+  focus: string;
+  summary: string;
+  plannedHours: number;
+  videoLinks: CurriculumResourceLink[];
+  buildSteps: string[];
+  definitionOfDone: string[];
+  artifactTargets: string[];
+}
+
+export interface CurriculumWeekMilestone {
+  week: number;
+  title: string;
+  summary: string;
+}
+
+export interface CurriculumWeekGroup {
+  week: number;
+  title: string;
+  days: CurriculumDayTemplate[];
+}
+
+export interface CurriculumProgress {
+  completedDays: number;
+  totalDays: number;
+  percent: number;
+}

--- a/types/curriculum.ts
+++ b/types/curriculum.ts
@@ -1,22 +1,6 @@
-export interface CurriculumResourceLink {
-  label: string;
-  url: string;
-}
+import type { CurriculumDay } from '@/content/curriculum/month1';
 
-export interface CurriculumDayTemplate {
-  id: string;
-  week: number;
-  day: number;
-  suggestedDate: string;
-  title: string;
-  focus: string;
-  summary: string;
-  plannedHours: number;
-  videoLinks: CurriculumResourceLink[];
-  buildSteps: string[];
-  definitionOfDone: string[];
-  artifactTargets: string[];
-}
+export type { CurriculumDay };
 
 export interface CurriculumWeekMilestone {
   week: number;
@@ -27,7 +11,7 @@ export interface CurriculumWeekMilestone {
 export interface CurriculumWeekGroup {
   week: number;
   title: string;
-  days: CurriculumDayTemplate[];
+  days: CurriculumDay[];
 }
 
 export interface CurriculumProgress {


### PR DESCRIPTION
## Summary
- add Month 1 curriculum source data (24 days) with reusable helpers
- upgrade /roadmap with Plan|Execution tabs, curriculum progress 0/24 defaults, and premium empty states
- add admin curriculum control panel with Vaul drawer details and one-click daily log creation
- auto-create Week 1..4 milestones before template log insertion

## Verification
- npm install
- npm run typecheck
- npm run lint
- npm run build